### PR TITLE
Ranger Constructor 1.0

### DIFF
--- a/miscellaneous/ranger-constructor.xml
+++ b/miscellaneous/ranger-constructor.xml
@@ -1,0 +1,3070 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+        <name>Ranger Constructor Class</name>
+        <description>The Ranger Class with ability to choose every feature.</description>
+        <author url="https://www.reddit.com/user/Nick_Vendel/">Nick Vendel</author>
+        <update version="0.0.1">
+            <file name="class-ranger.xml" url="https://raw.githubusercontent.com/NickVendel/experemental_elements/master/third-party/critical-role/classes/ranger-constructor.xml" />
+        </update>
+    </info>
+    <!-- Ranger -->
+    <element name="Ranger Constructor" type="Class" source="Player’s Handbook" id="ID_CLASS_RANGER_CONSTRUCTOR">
+        <supports />
+        <requirements />
+        <description>
+            <p><b>Description of original Ranger, doesn't include all possible features.</b></p>
+            <p class="flavor">A warrior who uses martial prowess and nature magic to combat threats on the edges of civilization.</p>
+            <p>Rough and wild looking, a human stalks alone through the shadows of trees, hunting the orcs he knows are planning a raid on a nearby farm. Clutching a shortsword in each hand, he becomes a whirlwind of steel, cutting down one enemy after another.</p>
+            <p class="indent">After tumbling away from a cone of freezing air, an elf finds her feet and draws back her bow to loose an arrow at the white dragon. Shrugging off the wave of fear that emanates from the dragon like the cold of its breath, she sends one arrow after another to find the gaps between the dragon’s thick scales.</p>
+            <p class="indent">Holding his hand high, a half-elf whistles to the hawk that circles high above him, calling the bird back to his side. Whispering instructions in Elvish, he points to the owlbear he’s been tracking and sends the hawk to distract the creature while he readies his bow.</p>
+            <p class="indent">Far from the bustle of cities and towns, past the hedges that shelter the most distant farms from the terrors of the wild, amid the dense-packed trees of trackless forests and across wide and empty plains, rangers keep their unending watch.</p>
+            <h4>DEADLY HUNTERS</h4>
+            <p>Warriors of the wilderness, rangers specialize in hunting the monsters that threaten the edges of civilization—humanoid raiders, rampaging beasts and monstrosities, terrible giants, and deadly dragons. They learn to track their quarry as a predator does, moving stealthily through the wilds and hiding themselves in brush and rubble. Rangers focus their combat training on techniques that are particularly useful against their specific favored foes.</p>
+            <p class="indent">Thanks to their familiarity with the wilds, rangers acquire the ability to cast spells that harness nature’s power, much as a druid does. Their spells, like their combat abilities, emphasize speed, stealth, and the hunt. A ranger’s talents and abilities are honed with deadly focus on the grim task of protecting the borderlands.</p>
+            <h4>INDEPENDENT ADVENTURERS</h4>
+            <p>Though a ranger might make a living as a hunter, a guide, or a tracker, a ranger’s true calling is to defend the outskirts of civilization from the ravages of monsters and humanoid hordes that press in from the wild. In some places, rangers gather in secretive orders or join forces with druidic circles. Many rangers, though, are independent almost to a fault, knowing that, when a dragon or a band of orcs attacks, a ranger might be the first—and possibly the last—line of defense.</p>
+            <p class="indent">This fierce independence makes rangers well suited to adventuring, since they are accustomed to life far from the comforts of a dry bed and a hot bath. Faced with city-bred adventurers who grouse and whine about the hardships of the wild, rangers respond with some mixture of amusement, frustration, and compassion. But they quickly learn that other adventurers who can carry their own weight in a fight against civilization’s foes are worth any extra burden. Coddled city folk might not know how to feed themselves or find fresh water in the wild, but they make up for it in other ways.</p>
+            <h4>CREATING A RANGER</h4>
+            <p>As you create your ranger character, consider the nature of the training that gave you your particular capabilities. Did you train with a single mentor, wandering the wilds together until you mastered the ranger’s ways? Did you leave your apprenticeship, or was your mentor slain— perhaps by the same kind of monster that became your favored enemy? Or perhaps you learned your skills as part of a band of rangers affiliated with a druidic circle, trained in mystic paths as well as wilderness lore. You might be self-taught, a recluse who learned combat skills, tracking, and even a magical connection to nature through the necessity of surviving in the wilds.</p>
+            <p class="indent">What’s the source of your particular hatred of a certain kind of enemy? Did a monster kill someone you loved or destroy your home village? Or did you see too much of the destruction these monsters cause and commit yourself to reining in their depredations? Is your adventuring career a continuation of your work in protecting the borderlands, or a significant change? What made you join up with a band of adventurers? Do you find it challenging to teach new allies the ways of the wild, or do you welcome the relief from solitude that they offer?</p>
+            <h5>QUICK BUILD</h5>
+            <p>You can make a ranger quickly by following these suggestions. First, make Dexterity your highest ability score, followed by Wisdom. (Some rangers who focus on two-weapon fighting make Strength higher than Dexterity.) Second, choose the outlander background.</p>
+            <h3>CLASS FEATURES</h3>
+            <p>As a ranger, you gain the following class features.</p>
+            <h5>HIT POINTS</h5>
+            <p>
+                <span class="emphasis">Hit Dice:</span>1d10 per ranger level
+                <br />
+                <span class="emphasis">Hit Points at 1st Level:</span>10 + your Constitution modifier
+                <br />
+                <span class="emphasis">Hit Points at Higher Levels:</span>1d10 (or 6) + your Constitution modifier per ranger level after 1st
+                <br />
+            </p>
+            <h5>PROFICIENCIES</h5>
+            <p>
+                <span class="emphasis">Armor:</span>Light armor, medium armor, shields
+                <br />
+                <span class="emphasis">Weapons:</span>Simple weapons, martial weapons
+                <br />
+                <span class="emphasis">Tools:</span>None
+                <br />
+            </p>
+            <p>
+                <span class="emphasis">Saving Throws:</span>Strength, Dexterity
+                <br />
+                <span class="emphasis">Skills:</span>Choose three skills from Animal Handling, Athletics, Insight, Investigation, Nature, Perception, Stealth, and Survival
+                <br />
+            </p>
+            <h5>EQUIPMENT</h5>
+            <p>You start with the following equipment, in addition to the equipment granted by your background:</p>
+            <ul>
+                <li>
+                    <i>(a)</i> scale mail or 
+                    <i>(b)</i> leather armor
+                </li>
+                <li>
+                    <i>(a)</i> two shortswords or 
+                    <i>(b)</i> two simple melee weapons
+                </li>
+                <li>
+                    <i>(a)</i> a dungeoneer’s pack or 
+                    <i>(b)</i> an explorer’s pack
+                </li>
+                <li>A longbow and a quiver of 20 arrows</li>
+            </ul>
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_FAVORED_ENEMY" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_NATURAL_EXPLORER" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_FIGHTING_STYLE" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_SPELLCASTING" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_RANGER_ARCHETYPE" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_ASI" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_EXTRA_ATTACK" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_LANDS_STRIDE" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_VANISH" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_FERAL_SENSES" />
+            <div element="ID_WOTC_CLASSFEATURE_RANGER_FOE_SLAYER" />
+        </description>
+        <sheet display="false" alt="Ranger">
+            <description>A warrior who uses martial prowess and nature magic to combat threats on the edges of civilization.</description>
+        </sheet>
+        <setters>
+            <set name="short">A warrior who uses martial prowess and nature magic to combat threats on the edges of civilization.</set>
+            <set name="hd">d10</set>
+            <!-- there's currently no way to select your Hit Die, for UA: Ranger's 2d6 -->
+        </setters>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_LIGHT_ARMOR" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_WEAPON_PROFICIENCY_SIMPLE_WEAPONS" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_WEAPONS" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <select type="Proficiency" name="Saving Throws (Ranger)" supports="Ranger Constructor, Saving Throws" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+            <select type="Proficiency" name="Skill Proficiency (Ranger)" supports="Skill,Ranger" number="3" requirements="!ID_MULTICLASS_RANGER_CONSTRUCTOR" />
+
+            <select type="Class Feature" name="1st Class Feature" supports="Ranger Constructor, 1st Class Feature" level="1" />
+            <select type="Class Feature" name="2nd Class Feature" supports="Ranger Constructor, 2nd Class Feature" level="1" />
+            <select type="Class Feature" name="3rd Class Feature" supports="Ranger Constructor, 3rd Class Feature" level="2" />
+            <select type="Class Feature" name="4th Class Feature" supports="Ranger Constructor, 4th Class Feature" level="2" />
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_RANGER_ARCHETYPE" level="3"/>
+            <!-- <select type="Class Feature" name="5th Class Feature" supports="Ranger Constructor, 5th Class Feature" level="3" /> -->
+            <select type="Class Feature" name="6th Class Feature" supports="Ranger Constructor, 6th Class Feature" level="3" />
+            <select type="Class Feature" name="7th Class Feature" supports="Ranger Constructor, 7th Class Feature" level="4" />
+            <select type="Class Feature" name="8th Class Feature" supports="Ranger Constructor, 8th Class Feature" level="5" />
+            <select type="Class Feature" name="9th Class Feature" supports="Ranger Constructor, 9th Class Feature" level="6" optional="true" />
+            <select type="Class Feature" name="10th Class Feature" supports="Ranger Constructor, 10th Class Feature" level="8" />
+            <select type="Class Feature" name="11th Class Feature" supports="Ranger Constructor, 11th Class Feature" level="9" optional="true" />
+            <select type="Class Feature" name="12th Class Feature" supports="Ranger Constructor, 12th Class Feature" level="10" />
+            <select type="Class Feature" name="13th Class Feature" supports="Ranger Constructor, 13th Class Feature" level="13" optional="true" />
+            <select type="Class Feature" name="14th Class Feature" supports="Ranger Constructor, 14th Class Feature" level="14" />
+            <select type="Class Feature" name="15th Class Feature" supports="Ranger Constructor, 15th Class Feature" level="17" optional="true" />
+            <select type="Class Feature" name="16th Class Feature" supports="Ranger Constructor, 16th Class Feature" level="18" />
+            <select type="Class Feature" name="17th Class Feature" supports="Ranger Constructor, 17th Class Feature" level="20" />
+<!-- 
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_EXTRA_ATTACK" level="5"/>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_LANDS_STRIDE" level="8"/>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT" level="10"/>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_VANISH" level="14"/>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FERAL_SENSES" level="18"/>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FOE_SLAYER" level="20"/> -->
+        </rules>
+        <multiclass id="ID_MULTICLASS_RANGER_CONSTRUCTOR">
+            <prerequisite>Dexterity 13 and Wisdom 13</prerequisite>
+            <requirements>([dex:13],[wis:13]),!ID_WOTC_PHB_CLASS_RANGER</requirements>
+            <setters>
+                <set name="multiclass proficiencies">Light armor, medium armor, shields, simple weapons, martial weapons, one skill from the class’s skill list</set>
+            </setters>
+            <rules>
+                <grant type="Grants" id="ID_INTERNAL_GRANT_MULTICLASS" />
+
+                <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_LIGHT_ARMOR" />
+                <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" />
+                <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" />
+                <grant type="Proficiency" id="ID_PROFICIENCY_WEAPON_PROFICIENCY_SIMPLE_WEAPONS" />
+                <grant type="Proficiency" id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_WEAPONS" />
+                <select type="Proficiency" name="Skill Proficiency (Ranger)" supports="Skill,Ranger" number="1"/>
+            </rules>
+        </multiclass>
+    </element>
+    <!-- Saving Throws -->
+    <element name="Strength and Dexterity" type="Proficiency" source="Player’s Handbook" id="ID_PHB_PROFICIENCY_SAVINGTHROW_STRENGTH_AND_DEXTERITY">
+        <supports>Ranger Constructor, Saving Throws</supports>
+        <description>
+            <p>You gain proficiency with Strength and Dexterity saving throws</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Strength and Dexterity saving throws</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_STRENGTH" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_DEXTERITY" />
+        </rules>
+    </element>
+    <element name="Dexterity and Wisdom" type="Proficiency" source="Unearthed Arcana: Ranger" id="ID_WOTC_UA20150909_PROFICIENCY_SAVINGTHROW_STRENGTH_AND_DEXTERITY">
+        <supports>Ranger Constructor, Saving Throws</supports>
+        <description>
+            <p>You gain proficiency with Dexterity and Wisdom saving throws</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Dexterity and Wisdom saving throws</description>
+        </sheet>
+        <setters>
+            <set name="sourceUrl">https://dnd.wizards.com/articles/unearthed-arcana/ranger</set>
+        </setters>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_DEXTERITY" />
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_WISDOM" />
+        </rules>
+    </element>
+
+    <!-- 1st Class Features GRANTS (Since sub-features stick to the last select, if you're selecting all features, i avoided it by creating a workaround to grant features via clone-elements) -->
+    <element name="Favored Enemy" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_FAVORED_ENEMY">
+        <supports>Ranger Constructor, 1st Class Feature</supports>
+        <description>
+            <p>Beginning at 1st level, you have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.</p>
+            <p class="indent">Choose a type of favored enemy: aberrations, beasts, celestials, constructs, dragons, elementals, fey, fiends, giants, monstrosities, oozes, plants, or undead. Alternatively, you can select two races of humanoid (such as gnolls and orcs) as favored enemies.</p>
+            <p class="indent">You have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</p>
+            <p class="indent">When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.</p>
+            <p class="indent">You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures.</p>
+        </description>
+        <sheet display="false">
+            <description>You have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FAVORED_ENEMY" />
+        </rules>
+    </element>
+    <element name="Favored Enemy" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_FAVORED_ENEMY">
+        <supports>Ranger Constructor, 1st Class Feature</supports>
+        <description>
+            <p>Beginning at 1st level, you have significant experience studying, tracking, hunting, and even talking to a certain type of enemy commonly encountered in the wilds.</p>
+            <!-- added oozes and plants as basic Favored Enemies -->
+            <p class="indent">Choose a type of favored enemy: beasts, fey, humanoids, monstrosities, oozes, plants or undead. You gain a +2 bonus to damage rolls with weapon attacks against creatures of the chosen type. Additionally, you have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</p>
+            <p class="indent">When you gain this feature, you also learn one language of your choice, typically one spoken by your favored enemies or creatures associated with it. However, you are free to pick any language you wish to learn.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain a +2 bonus to damage rolls with weapon attacks against creatures of the chosen type. You also have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+            <description level="6">You gain a +4 bonus to damage rolls with weapon attacks against creatures of the chosen type. You also have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY" />
+        </rules>
+    </element>
+    <element name="Ambuscade" type="Class Feature" source="Unearthed Arcana: Ranger" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_CONSTRUCTOR_AMBUSCADE">
+        <supports>Ranger Constructor, 1st Class Feature</supports>
+        <description>
+            <p>Beginning at 1st level, you strike first and strike hard. When you roll initiative, you gain a special turn that takes place before other creatures can act. On this turn, you can use your action to take either the Attack or Hide action.</p>
+            <p class="indent">If more than one creature in an encounter has this feature, they all act first in order of initiative, then the regular initiative order begins.</p>
+            <p class="indent">If you would normally be surprised at the start of an encounter, you are not surprised but you do not gain this extra turn.</p>
+        </description>
+        <sheet display="false">
+            <description>When you roll initiative, you gain a special turn that takes place before other creatures can act. On this turn, you can use your action to take either the Attack or Hide action. If you would normally be surprised at the start of an encounter, you are not surprised but you do not gain this extra turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_AMBUSCADE" />
+        </rules>
+    </element>
+    <element name="Favored Foe" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_FAVORED_FOE">
+        <supports>Ranger Constructor, 1st Class Feature</supports>
+        <description>
+            <p>You can call on your bond with nature to mark a creature as your favored enemy for a time: you know the <i>hunter’s mark</i> spell, and Wisdom is your spellcasting ability for it. You can use it a certain number of times without expending a spell slot and without requiring concentration — a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</p>
+            <p class="indent">When you gain the Spellcasting feature at 2nd level, <i>hunter’s mark</i> doesn’t count against the number of ranger spells you know.</p>
+        </description>
+        <sheet display="false">
+            <description>You know the <i>hunter’s mark</i> spell, and Wisdom is your spellcasting ability for it. You can use it a certain number of times without expending a spell slot and without requiring concentration — a number of times equal to {{favored foe:uses}}.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FAVORED_FOE" />
+        </rules>
+    </element>
+
+    <!-- 1st Class Features -->
+    <element name="Favored Enemy" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_FAVORED_ENEMY">
+        <description>
+            <p>Beginning at 1st level, you have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.</p>
+            <p class="indent">Choose a type of favored enemy: aberrations, beasts, celestials, constructs, dragons, elementals, fey, fiends, giants, monstrosities, oozes, plants, or undead. Alternatively, you can select two races of humanoid (such as gnolls and orcs) as favored enemies.</p>
+            <p class="indent">You have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</p>
+            <p class="indent">When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.</p>
+            <p class="indent">You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures.</p>
+        </description>
+        <sheet>
+            <description>You have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Favored Enemy" supports="Favored Enemy" level="1" />
+            <select type="Class Feature" name="Favored Enemy" supports="Favored Enemy" level="6" />
+            <select type="Class Feature" name="Favored Enemy" supports="Favored Enemy" level="14" />
+            <select type="Language" name="Language (Favored Enemy)" level="1" />
+            <select type="Language" name="Language (Favored Enemy)" level="6" />
+            <select type="Language" name="Language (Favored Enemy)" level="14" />
+        </rules>
+    </element>
+
+    <element name="Favored Enemy" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY">
+        <description>
+            <p>Beginning at 1st level, you have significant experience studying, tracking, hunting, and even talking to a certain type of enemy commonly encountered in the wilds.</p>
+            <!-- added oozes and plants as basic Favored Enemies -->
+            <p class="indent">Choose a type of favored enemy: beasts, fey, humanoids, monstrosities, oozes, plants or undead. You gain a +2 bonus to damage rolls with weapon attacks against creatures of the chosen type. Additionally, you have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</p>
+            <p class="indent">When you gain this feature, you also learn one language of your choice, typically one spoken by your favored enemies or creatures associated with it. However, you are free to pick any language you wish to learn.</p>
+        </description>
+        <sheet>
+            <description>You gain a +2 bonus to damage rolls with weapon attacks against creatures of the chosen type. You also have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+            <description level="6">You gain a +4 bonus to damage rolls with weapon attacks against creatures of the chosen type. You also have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Favored Enemy" supports="Revised Favored Enemy" level="1" />
+            <select type="Language" name="Language (Favored Enemy)" level="1" />
+        </rules>
+    </element>
+  <!-- Favored Enemies-->
+    <element name="Beasts" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_BEAST">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Beasts are nonhumanoid creatures that are a natural part of the fantasy ecology. Some of them have magical powers, but most are unintelligent and lack any society or language. Beasts include all varieties of ordinary animals, dinosaurs, and giant versions of animals.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Fey" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_FEY">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Fey are magical creatures closely tied to the forces of nature. They dwell in twilight groves and misty forests. In some worlds, they are closely tied to the Feywild, also called the Plane of Faerie. Some are also found in the Outer Planes, particularly the planes of Arborea and the Beastlands. Fey include dryads, pixies, and satyrs.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Monstrosities" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_MONSTROSITIES">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Monstrosities are monsters in the strictest sensefrightening creatures that are not ordinary, not truly natural, and almost never benign. Some are the results of magical experimentation gone awry (such as owl bears), and others ,are the product-of terrible curses (including minotaurs and yuan-ti). They defy categorization, and in some sense serve as a catch-all category for creatures that don't fit into any other type.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Oozes" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_OOZES">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Oozes are gelatinous creatures that rarely have a fixed shape. They are mostly subterranean, dwelling in caves and dungeons and feeding on refuse, carrion, or creatures unlucky enough to get in their way. Black puddings and gelatinous cubes are among the most recognizable oozes.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Plants" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_PLANTS">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Plants in this context are vegetable creatures, not ordinary flora. Most of them are ambulatory, and some are carnivorous. The quintessential plants are the shambling mound and the treant. Fungal creatures such as the gas spore and the myconid also fall into this category.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Undead" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_UNDEAD">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Undead are once-living creatures brought to a horrifying state of undeath through the practice of necromantic magic or some unholy curse. Undead include walking corpses, such as vampires and zombies, as well as bodiless spirits, such as ghosts and specters.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+    <element name="Humanoids" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FAVORED_ENEMY_HUMANOIDS">
+        <supports>Revised Favored Enemy</supports>
+        <description>
+            <p>Humanoids are the main peoples of the D&amp;D world, both civilized and savage, including humans and a tremendous variety of other species. They have language and culture, few if any innate magical abilities (though most humanoids can learn spellcasting), and a bipedal form. The most common humanoid races are the ones most suitable as player characters: humans, dwarves, elves, and halflings. Almost as numerous but far more savage and brutal, and almost uniformly evil, are the races of goblinoids (golblins, hobgoblins, and bugbears), orcs, gnolls, lizardfolk, and kobolds. A variety of humanoids appear throughout this book, but the races detailed in the Player's Handbook- with the exception of drow-are dealt with in appendix B. That appendix gives you a number of stat blocks that you·can use to make various members of those races.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+    </element>
+
+    <element name="Ambuscade" type="Class Feature" source="Unearthed Arcana: Ranger" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_AMBUSCADE">
+        <description>
+            <p>Beginning at 1st level, you strike first and strike hard. When you roll initiative, you gain a special turn that takes place before other creatures can act. On this turn, you can use your action to take either the Attack or Hide action.</p>
+            <p class="indent">If more than one creature in an encounter has this feature, they all act first in order of initiative, then the regular initiative order begins.</p>
+            <p class="indent">If you would normally be surprised at the start of an encounter, you are not surprised but you do not gain this extra turn.</p>
+        </description>
+        <sheet>
+            <description>When you roll initiative, you gain a special turn that takes place before other creatures can act. On this turn, you can use your action to take either the Attack or Hide action. If you would normally be surprised at the start of an encounter, you are not surprised but you do not gain this extra turn.</description>
+        </sheet>
+    </element>
+
+    <element name="Favored Foe" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FAVORED_FOE">
+        <description>
+            <p>You can call on your bond with nature to mark a creature as your favored enemy for a time: you know the <i>hunter’s mark</i> spell, and Wisdom is your spellcasting ability for it. You can use it a certain number of times without expending a spell slot and without requiring concentration — a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</p>
+            <p class="indent">When you gain the Spellcasting feature at 2nd level, <i>hunter’s mark</i> doesn’t count against the number of ranger spells you know.</p>
+        </description>
+        <sheet usage="{{favored foe:uses}}/Long Rest">
+            <description>You know the <i>hunter’s mark</i> spell, and Wisdom is your spellcasting ability for it. You can use it a certain number of times without expending a spell slot and without requiring concentration — a number of times equal to {{favored foe:uses}}.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_HUNTERS_MARK" />
+            <stat name="favored foe:uses" value="1" bonus="base" />
+            <stat name="favored foe:uses" value="wisdom:modifier" bonus="base" />
+        </rules>
+    </element>
+
+    <!-- 2nd Class Features GRANTS -->
+    <element name="Natural Explorer" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_NATURAL_EXPLORER">
+        <supports>Ranger Constructor, 2nd Class Feature</supports>
+        <description>
+            <p>You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions. Choose one type of favored terrain: arctic, coast, desert, forest, grassland, mountain, swamp, or the Underdark. When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you’re proficient in.</p>
+            <p class="indent">While traveling for an hour or more in your favored terrain, you gain the following benefits:</p>
+            <ul>
+                <li>Difficult terrain doesn’t slow your group’s travel.</li>
+                <li>Your group can’t become lost except by magical means.</li>
+                <li>Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger.</li>
+                <li>If you are traveling alone, you can move stealthily at a normal pace.</li>
+                <li>When you forage, you find twice as much food as you normally would.</li>
+                <li>While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</li>
+            </ul>
+            <p class="indent">You choose additional favored terrain types at 6th and 10th level.</p>
+        </description>
+        <sheet display="false">
+            <description>When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you’re proficient in. While traveling for an hour or more in your favored terrain, you gain benefits.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_NATURAL_EXPLORER" />
+        </rules>
+    </element>
+    <element name="Natural Explorer" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_NATURAL_EXPLORER">
+        <supports>Ranger Constructor, 2nd Class Feature</supports>
+        <description>
+            <p>You are a master of navigating the natural world, and you react with swift and decisive action when attacked. This grants you the following benefits:</p>
+            <ul>
+                <li>You ignore difficult terrain.</li>
+                <li>You have advantage on initiative rolls.</li>
+                <li>On your first turn during combat, you have advantage on attack rolls against creatures that have not yet acted.</li>
+            </ul>
+            <p>In addition, you are skilled at navigating the wilderness. You gain following benefits when traveling for an hour of more:</p>
+            <ul>
+                <li>Difficult terrain doesn’t slow your group’s travel.</li>
+                <li>Your group can’t become lost except by magical means.</li>
+                <li>Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger.</li>
+                <li>If you are traveling alone, you can move stealthily at a normal pace.</li>
+                <li>When you forage, you find twice as much food as you normally would.</li>
+                <li>While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</li>
+            </ul>
+        </description>
+        <sheet display="false">
+            <description>You ignore difficult terrain and have advantage on initiative rolls. On your first turn during combat, you have advantage on attack rolls against creatures that have not yet acted. You gain following benefits when traveling for an hour of more: Difficult terrain doesn’t slow your group’s travel and group can’t become lost except by magical means. Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger. If you are traveling alone, you can move stealthily at a normal pace. When you forage, you find twice as much food as you normally would. While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_NATURAL_EXPLORER" />
+        </rules>
+    </element>
+    <element name="Deft Explorer" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_DEFT_EXPLORER">
+        <supports>Ranger Constructor, 2nd Class Feature</supports>
+        <description>
+            <p>You are an unsurpassed explorer and survivor. Choose one of the following benefits, and then choose another one at 6th and 10th level.</p>
+            <p><b><i>Canny.</i></b> Choose one skill: Animal Handling, Athletics, History, Insight, Investigation, Medicine, Nature, Perception, Stealth, or Survival. You gain proficiency in the chosen skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+            <p class="indent">In addition, thanks to your extensive wandering, you are able to speak, read, and write two languages of your choice.</p>
+            <p><b><i>Roving.</i></b> Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</p>
+            <p><b><i>Tireless.</i></b> As an action, you can give yourself a number of temporary hit points equal to 1d10 + your Wisdom modifier. You can use this special action a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a long rest.</p>
+            <p class="indent">In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</p>
+        </description>
+        <sheet display="false">
+            <description>You are an unsurpassed explorer and survivor.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_DEFT_EXPLORER" />
+        </rules>
+    </element>
+
+    <!-- 2nd Class Features -->
+    <element name="Natural Explorer" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_NATURAL_EXPLORER">
+        <description>
+            <p>You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions. Choose one type of favored terrain: arctic, coast, desert, forest, grassland, mountain, swamp, or the Underdark. When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you’re proficient in.</p>
+            <p class="indent">While traveling for an hour or more in your favored terrain, you gain the following benefits:</p>
+            <ul>
+                <li>Difficult terrain doesn’t slow your group’s travel.</li>
+                <li>Your group can’t become lost except by magical means.</li>
+                <li>Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger.</li>
+                <li>If you are traveling alone, you can move stealthily at a normal pace.</li>
+                <li>When you forage, you find twice as much food as you normally would.</li>
+                <li>While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</li>
+            </ul>
+            <p class="indent">You choose additional favored terrain types at 6th and 10th level.</p>
+        </description>
+        <sheet>
+            <description>When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you’re proficient in. While traveling for an hour or more in your favored terrain, you gain benefits.</description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Favored Terrain" supports="Favored Terrain" level="1" />
+            <select type="Class Feature" name="Favored Terrain" supports="Favored Terrain" level="6" />
+            <select type="Class Feature" name="Favored Terrain" supports="Favored Terrain" level="10" />
+        </rules>
+    </element>
+
+    <element name="Natural Explorer" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_NATURAL_EXPLORER">
+        <description>
+            <p>You are a master of navigating the natural world, and you react with swift and decisive action when attacked. This grants you the following benefits:</p>
+            <ul>
+                <li>You ignore difficult terrain.</li>
+                <li>You have advantage on initiative rolls.</li>
+                <li>On your first turn during combat, you have advantage on attack rolls against creatures that have not yet acted.</li>
+            </ul>
+            <p>In addition, you are skilled at navigating the wilderness. You gain following benefits when traveling for an hour of more:</p>
+            <ul>
+                <li>Difficult terrain doesn’t slow your group’s travel.</li>
+                <li>Your group can’t become lost except by magical means.</li>
+                <li>Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger.</li>
+                <li>If you are traveling alone, you can move stealthily at a normal pace.</li>
+                <li>When you forage, you find twice as much food as you normally would.</li>
+                <li>While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</li>
+            </ul>
+        </description>
+        <sheet>
+            <description>You ignore difficult terrain and have advantage on initiative rolls. On your first turn during combat, you have advantage on attack rolls against creatures that have not yet acted. You gain following benefits when traveling for an hour of more: Difficult terrain doesn’t slow your group’s travel and group can’t become lost except by magical means. Even when you are engaged in another activity while traveling (such as foraging, navigating, or tracking), you remain alert to danger. If you are traveling alone, you can move stealthily at a normal pace. When you forage, you find twice as much food as you normally would. While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.</description>
+        </sheet>
+        <rules />
+    </element>
+
+    <element name="Deft Explorer" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_DEFT_EXPLORER">
+        <description>
+            <p>You are an unsurpassed explorer and survivor. Choose one of the following benefits, and then choose another one at 6th and 10th level.</p>
+            <p><b><i>Canny.</i></b> Choose one skill: Animal Handling, Athletics, History, Insight, Investigation, Medicine, Nature, Perception, Stealth, or Survival. You gain proficiency in the chosen skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+            <p class="indent">In addition, thanks to your extensive wandering, you are able to speak, read, and write two languages of your choice.</p>
+            <p><b><i>Roving.</i></b> Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</p>
+            <p><b><i>Tireless.</i></b> As an action, you can give yourself a number of temporary hit points equal to 1d10 + your Wisdom modifier. You can use this special action a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a long rest.</p>
+            <p class="indent">In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</p>
+        </description>
+        <sheet>
+            <description>You are an unsurpassed explorer and survivor.</description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Deft Explorer (Level 1)" supports="Deft Explorer" level="1"/>
+            <select type="Class Feature" name="Deft Explorer (Level 6)" supports="Deft Explorer" level="6"/>
+            <select type="Class Feature" name="Deft Explorer (Level 10)" supports="Deft Explorer" level="10"/>
+        </rules>
+    </element>
+
+    <!-- Deft Explorer Features -->
+    <element name="Canny" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY">
+        <supports>Deft Explorer</supports>
+        <description>
+            <p>Choose one skill: Animal Handling, Athletics, History, Insight, Investigation, Medicine, Nature, Perception, Stealth, or Survival. You gain proficiency in the chosen skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+            <p class="indent">In addition, thanks to your extensive wandering, you are able to speak, read, and write two languages of your choice.</p>
+        </description>
+        <sheet />
+        <rules>
+            <select type="Proficiency" name="Skill Proficiency (Canny)" supports="Canny, Proficiencies" />
+            <select type="Language" name="Language (Canny)" number="2" />
+        </rules>
+    </element>
+    <element name="Roving" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_ROVING">
+        <supports>Deft Explorer</supports>
+        <description>
+            <p>Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</p>
+        </description>
+        <sheet />
+        <rules>
+            <stat name="speed" value="5" />
+			<stat name="speed:swim" value="speed" bonus="base" />
+			<stat name="speed:fly" value="speed" bonus="base" />
+        </rules>
+    </element>
+    <element name="Tireless" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_TIRELESS">
+        <supports>Deft Explorer</supports>
+        <description>
+            <p>As an action, you can give yourself a number of temporary hit points equal to 1d10 + your Wisdom modifier. You can use this special action a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a long rest.</p>
+            <p class="indent">In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</p>
+        </description>
+        <sheet usage="{{tireless:uses}}/Long Rest" action="Action">
+            <description>You can give yourself a number of temporary hit points equal to 1d10 + {{wisdom:modifier}}. In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</description>
+        </sheet>
+        <rules>
+            <stat name="tireless:uses" value="1" bonus="base" />
+            <stat name="tireless:uses" value="wisdom:modifier" bonus="base" />
+        </rules>
+    </element>
+
+    <!-- Canny Proficiencies -->
+    <element name="Animal Handling" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_ANIMAL_HANDLING">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Animal Handling skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Animal Handling skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_ANIMALHANDLING" />
+			<stat name="animal handling:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Athletics" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_ATHLETICS">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Athletics skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Athletics skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_ATHLETICS" />
+			<stat name="athletics:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="History" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_HISTORY">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with History skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with History skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_HISTORY" />
+			<stat name="history:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Insight" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_INSIGHT">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Insight skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Insight skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_INSIGHT" />
+			<stat name="insight:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Investigation" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_INVESTIGATION">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Investigation skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Investigation skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_INVESTIGATION" />
+			<stat name="investigation:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Medicine" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_MEDICINE">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Medicine skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Medicine skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_MEDICINE" />
+			<stat name="medicine:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Nature" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_NATURE">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Nature skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Nature skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_NATURE" />
+			<stat name="nature:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Perception" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_PERCEPTION">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Perception skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Perception skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERCEPTION" />
+			<stat name="perception:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Stealth" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_STEALTH">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Stealth skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Stealth skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_STEALTH" />
+			<stat name="stealth:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+    <element name="Survival" type="Proficiency" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CANNY_SURVIVAL">
+        <supports>Canny, Proficiencies</supports>
+        <description>
+            <p>You gain proficiency with Survival skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</p>
+        </description>
+        <sheet display="false">
+            <description>You gain proficiency with Survival skill if you don’t already have it, and you can add double your proficiency bonus to ability checks using that skill.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_SURVIVAL" />
+			<stat name="survival:proficiency" value="proficiency" bonus="double" />
+        </rules>
+    </element>
+
+    <!-- 3rd Class Features GRANTS -->
+    <element name="Fighting Style" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_FIGHTING_STYLE">
+        <supports>Ranger Constructor, 3rd Class Feature</supports>
+        <description>
+            <p>At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.</p>
+            <h5>ARCHERY</h5>
+            <p>You gain a +2 bonus to attack rolls you make with ranged weapons.</p>
+            <h5>DEFENSE</h5>
+            <p>While you are wearing armor, you gain a +1 bonus to AC.</p>
+            <h5>DUELING</h5>
+            <p>When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.</p>
+            <h5>TWO-WEAPON FIGHTING</h5>
+            <p>When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.</p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FIGHTING_STYLE" />
+        </rules>
+    </element>
+    <element name="Fighting Style (Enhanced)" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_FIGHTING_STYLE">
+        <supports>Ranger Constructor, 3rd Class Feature</supports>
+        <description>
+            <p>At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.</p>
+            <h5>ARCHERY</h5>
+            <p>You gain a +2 bonus to attack rolls you make with ranged weapons.</p>
+            <h5>DEFENSE</h5>
+            <p>While you are wearing armor, you gain a +1 bonus to AC.</p>
+            <h5>DUELING</h5>
+            <p>When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.</p>
+            <h5>TWO-WEAPON FIGHTING</h5>
+            <p>When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.</p>
+            <h5>DRUIDIC WARRIOR</h5>
+            <p>You learn two cantrips of your choice from the druid spell list. They count as druid spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a level in this class, you can replace one of these cantrips with another cantrip from the druid spell list.</p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FIGHTING_STYLE" />
+        </rules>
+    </element>
+
+    <!-- 3rd Class Features -->
+    <element name="Fighting Style" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_FIGHTING_STYLE">
+        <description>
+            <p>At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.</p>
+            <h5>ARCHERY</h5>
+            <p>You gain a +2 bonus to attack rolls you make with ranged weapons.</p>
+            <h5>DEFENSE</h5>
+            <p>While you are wearing armor, you gain a +1 bonus to AC.</p>
+            <h5>DUELING</h5>
+            <p>When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.</p>
+            <h5>TWO-WEAPON FIGHTING</h5>
+            <p>When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Fighting Style" supports="Fighting Style,Ranger" level="2"/>
+        </rules>
+    </element>
+
+    <element name="Fighting Style (Enhanced)" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FIGHTING_STYLE">
+        <description>
+            <p>At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.</p>
+            <h5>ARCHERY</h5>
+            <p>You gain a +2 bonus to attack rolls you make with ranged weapons.</p>
+            <h5>DEFENSE</h5>
+            <p>While you are wearing armor, you gain a +1 bonus to AC.</p>
+            <h5>DUELING</h5>
+            <p>When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.</p>
+            <h5>TWO-WEAPON FIGHTING</h5>
+            <p>When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.</p>
+            <h5>DRUIDIC WARRIOR</h5>
+            <p>You learn two cantrips of your choice from the druid spell list. They count as druid spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a level in this class, you can replace one of these cantrips with another cantrip from the druid spell list.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Fighting Style" supports="(Fighting Style,Ranger)||(Fighting Style, Enhanced Ranger)" level="2"/>
+        </rules>
+    </element>
+
+    <element name="Druidic Warrior" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASS_FEATURE_FIGHTINGSTYLE_DRUIDIC_WARRIOR">
+        <supports>Fighting Style, Enhanced Ranger</supports>
+        <description>
+            <p>You learn two cantrips of your choice from the druid spell list. They count as druid spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a level in this class, you can replace one of these cantrips with another cantrip from the druid spell list.</p>
+        </description>
+        <sheet>
+            <description>You learn two cantrips of your choice from the druid spell list. They count as druid spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a level in this class, you can replace one of these cantrips with another cantrip from the druid spell list.</description>
+        </sheet>
+        <rules>
+            <select type="Spell" name="Cantrip (Druidic Warrior)" supports="Druid,0" number="2" />
+        </rules>
+    </element>
+
+    <!-- 4th Class Features GRANTS -->
+    <element name="Spellcasting" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_SPELLCASTING">
+        <supports>Ranger Constructor, 4th Class Feature</supports>
+        <description>
+            <p>By the time you reach 2nd level, you have learned to use the magical essence of nature to cast spells, much as a druid does. See chapter 10 for the general rules of spellcasting and chapter 11 for the ranger spell list.</p>
+            <h5>SPELL SLOTS</h5>
+            <p>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell’s level or higher. You regain all expended spell slots when you finish a long rest.</p>
+            <p class="indent">For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot.</p>
+            <h5>SPELLS KNOWN OF 1ST LEVEL AND HIGHER</h5>
+            <p>You know two 1st-level spells of your choice from the ranger spell list.</p>
+            <p class="indent">The Spells Known column of the Ranger table shows when you learn more ranger spells of your choice. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</p>
+            <p class="indent">Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots.</p>
+            <h5>SPELLCASTING ABILITY</h5>
+            <p>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</p>
+            <p class="indent">
+                <b>Spell save DC = 8</b> + your proficiency bonus + your Wisdom modifier
+            </p>
+            <p class="indent">
+                <b>Spell attack modifier =</b> your proficiency bonus + your Wisdom modifier
+            </p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_SPELLCASTING"/>
+        </rules>
+    </element>
+	<element name="Combat Superiority" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_COMBAT_SUPERIORITY">
+        <supports>Ranger Constructor, 4th Class Feature</supports>
+		<description>
+			<p>At 2nd level, you learn maneuvers that are fueled by special dice called superiority dice.</p>
+			<p class="indent"><b>Maneuvers.</b> You learn two maneuvers of your choice, which are chosen from the list of maneuvers available to fighters with the Battle Master archetype. Many maneuvers enhance an attack in some way. You can use only one maneuver per attack.</p>
+			<p class="indent">You learn one additional maneuver of your choice at 5th, 9th, 13th, and 17th levels. Each time you learn a new maneuver, you can also replace one maneuver you know with a different one.</p>
+			<p class="indent"><b>Superiority Dice.</b> You have four superiority dice, which are d8s. A superiority die is expended when you use it. You regain all of your expended superiority dice when you finish a short or long rest.</p>
+			<p class="indent">You gain another superiority die at 9th level and one more at 17th level.</p>
+			<p class="indent"><b>Saving Throws.</b> Some of your maneuvers require your target to make a saving throw to resist the maneuver’s effects. The saving throw DC is calculated as follows:</p>
+			<p><b>Maneuver save DC</b> = 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).</p>
+		</description>
+		<sheet display="false">
+			<description>You learn maneuvers that are fueled by special dice called superiority dice. You have {{superiority dice:amount}} superiority dice which are d8s. Your DC is {{superiority dice:dc}}.</description>
+		</sheet>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_COMBAT_SUPERIORITY" />
+		</rules>
+	</element>
+	<element name="Skirmisher’s Stealth" type="Class Feature" source="Unearthed Arcana: Ranger" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_CONSTRUCTOR_SKIRMISHERS_STEALTH">
+        <supports>Ranger Constructor, 4th Class Feature</supports>
+		<description>
+			<p>Beginning at 2nd level, you combine speed and stealth in combat to make yourself hard to pin down. You are difficult to detect even if you attack or otherwise take actions that would normally reveal your presence.</p>
+			<p class="indent">At the start of your turn, pick a creature you are hidden from. You remain hidden from that creature during your turn, regardless of your actions or the actions of other creatures. As a bonus action at the end of your turn, you can make a Dexterity (Stealth) check to hide again if you fulfill the conditions needed to hide. Otherwise, creatures are aware of you at the end of your turn.</p>
+		</description>
+		<sheet display="false">
+			<description>At the start of your turn, pick a creature you are hidden from. You remain hidden from that creature during your turn, regardless of your actions or the actions of other creatures. As a bonus action at the end of your turn, you can make a Dexterity (Stealth) check to hide again if you fulfill the conditions needed to hide. Otherwise, creatures are aware of you at the end of your turn.</description>
+		</sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_SKIRMISHERS_STEALTH" />
+        </rules>
+	</element>
+    <element name="Spellcasting (Enhanced)" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_SPELLCASTING">
+        <supports>Ranger Constructor, 4th Class Feature</supports>
+        <description>
+            <p>By the time you reach 2nd level, you have learned to use the magical essence of nature to cast spells, much as a druid does. See chapter 10 for the general rules of spellcasting and chapter 11 for the ranger spell list.</p>
+            <h5>SPELL SLOTS</h5>
+            <p>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell’s level or higher. You regain all expended spell slots when you finish a long rest.</p>
+            <p class="indent">For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot.</p>
+            <h5>SPELLS KNOWN OF 1ST LEVEL AND HIGHER</h5>
+            <p>You know two 1st-level spells of your choice from the ranger spell list.</p>
+            <p class="indent">The Spells Known column of the Ranger table shows when you learn more ranger spells of your choice. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</p>
+            <p class="indent">Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots.</p>
+            <h5>SPELLCASTING ABILITY</h5>
+            <p>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</p>
+            <p class="indent">
+                <b>Spell save DC = 8</b> + your proficiency bonus + your Wisdom modifier
+            </p>
+            <p class="indent">
+                <b>Spell attack modifier =</b> your proficiency bonus + your Wisdom modifier
+            </p>
+            <h5>SPELL VERSATILITY</h5>
+            <p>Whenever you finish a long rest, you can replace one spell you learned from this Spellcasting feature with another spell from the ranger spell list. The new spell must be the same level as the spell you replace.</p>
+            <h5>SPELLCASTING FOCUS</h5>
+            <p>You can use a druidic focus as a spellcasting focus for your ranger spells. See chapter 5, “Equipment,” of the <i>Player’s Handbook</i> for a list of things that count as druidic focuses.</p>
+            <h5>RANGER SPELLS</h5>
+            <p>The following spells expand the ranger spell list:</p>
+            <table>
+                <thead>
+                    <tr><td>Spell Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>1st</td><td><s>aid</s><em>, entangle, searing smite</em></td></tr>
+                <tr><td>2nd</td><td><em>(aid), gust of wind, magic weapon, enhance ability, warding bond</em></td></tr>
+                <tr><td>3rd</td><td><em>blinding smite, meld into stone, revivify, tongues</em></td></tr>
+                <tr><td>4th</td><td><em>death ward, dominate beast</em></td></tr>
+                <tr><td>5th</td><td><em>awaken, greater restoration</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_SPELLCASTING"/>
+            <grant type="Grants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_SPELLCASTING_EXPAND" />
+        </rules>
+    </element>
+
+    <!-- 4th Class Features -->
+    <element name="Spellcasting" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_SPELLCASTING">
+      <description>
+        <p>By the time you reach 2nd level, you have learned to use the magical essence of nature to cast spells, much as a druid does. See chapter 10 for the general rules of spellcasting and chapter 11 for the ranger spell list.</p>
+        <h5>SPELL SLOTS</h5>
+        <p>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell’s level or higher. You regain all expended spell slots when you finish a long rest.</p>
+        <p class="indent">For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot.</p>
+        <h5>SPELLS KNOWN OF 1ST LEVEL AND HIGHER</h5>
+        <p>You know two 1st-level spells of your choice from the ranger spell list.</p>
+        <p class="indent">The Spells Known column of the Ranger table shows when you learn more ranger spells of your choice. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</p>
+        <p class="indent">Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots.</p>
+        <h5>SPELLCASTING ABILITY</h5>
+        <p>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</p>
+        <p class="indent">
+          <b>Spell save DC = 8</b> + your proficiency bonus + your Wisdom modifier
+        </p>
+        <p class="indent">
+          <b>Spell attack modifier =</b> your proficiency bonus + your Wisdom modifier
+        </p>
+      </description>
+      <sheet display="false">
+        <description></description>
+      </sheet>
+      <spellcasting name="Ranger" ability="Wisdom" allowReplace="true">
+        <list>Ranger</list>
+      </spellcasting>
+      <rules>
+          <grant type="Grants" id="ID_INTERNAL_GRANT_MULTICLASS_SPELLCASTING_SLOTS_HALF" requirements="ID_INTERNAL_GRANT_MULTICLASS"/>
+
+          <stat name="ranger:spellcasting:slots:1" value="2" level="2" />
+          <stat name="ranger:spellcasting:slots:1" value="1" level="3" />
+          <stat name="ranger:spellcasting:slots:1" value="1" level="5" />
+          <stat name="ranger:spellcasting:slots:2" value="2" level="5" />
+          <stat name="ranger:spellcasting:slots:2" value="1" level="7" />
+          <stat name="ranger:spellcasting:slots:3" value="2" level="9" />
+          <stat name="ranger:spellcasting:slots:3" value="1" level="11" />
+          <stat name="ranger:spellcasting:slots:4" value="1" level="13" />
+          <stat name="ranger:spellcasting:slots:4" value="1" level="15" />
+          <stat name="ranger:spellcasting:slots:4" value="1" level="17" />
+          <stat name="ranger:spellcasting:slots:5" value="1" level="17" />
+          <stat name="ranger:spellcasting:slots:5" value="1" level="19" />
+
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="2" number="2" spellcasting="Ranger"/>
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="3" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="5" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="7" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="9" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="11" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="13" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="15" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="17" spellcasting="Ranger" />
+          <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="19" spellcasting="Ranger" />
+      </rules>
+    </element>
+
+	<element name="Combat Superiority" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_COMBAT_SUPERIORITY">
+		<description>
+			<p>At 2nd level, you learn maneuvers that are fueled by special dice called superiority dice.</p>
+			<p class="indent"><b>Maneuvers.</b> You learn two maneuvers of your choice, which are chosen from the list of maneuvers available to fighters with the Battle Master archetype. Many maneuvers enhance an attack in some way. You can use only one maneuver per attack.</p>
+			<p class="indent">You learn one additional maneuver of your choice at 5th, 9th, 13th, and 17th levels. Each time you learn a new maneuver, you can also replace one maneuver you know with a different one.</p>
+			<p class="indent"><b>Superiority Dice.</b> You have four superiority dice, which are d8s. A superiority die is expended when you use it. You regain all of your expended superiority dice when you finish a short or long rest.</p>
+			<p class="indent">You gain another superiority die at 9th level and one more at 17th level.</p>
+			<p class="indent"><b>Saving Throws.</b> Some of your maneuvers require your target to make a saving throw to resist the maneuver’s effects. The saving throw DC is calculated as follows:</p>
+			<p><b>Maneuver save DC</b> = 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).</p>
+		</description>
+		<sheet>
+			<description>You learn maneuvers that are fueled by special dice called superiority dice. You have {{superiority dice:amount}} superiority dice which are d8s. Your DC is {{superiority dice:dc}}.</description>
+		</sheet>
+		<rules>
+			<stat name="superiority dice:amount" value="4" />
+			<stat name="superiority dice:amount" value="1" level="9" />
+			<stat name="superiority dice:amount" value="1" level="17" />
+			<stat name="superiority dice:dc" value="8" />
+			<stat name="superiority dice:dc" value="proficiency" />
+			<stat name="superiority dice:dc:ability" value="strength:modifier" bonus="ability"/>
+			<stat name="superiority dice:dc:ability" value="dexterity:modifier" bonus="ability"/>
+			<stat name="superiority dice:dc" value="superiority dice:dc:ability" />
+			<select type="Archetype Feature" name="Combat Superiority (Level 2)" supports="Maneuver,Battle Master" number="2" />
+			<select type="Archetype Feature" name="Combat Superiority (Level 5)" supports="Maneuver,Battle Master" level="5" />
+			<select type="Archetype Feature" name="Combat Superiority (Level 9)" supports="Maneuver,Battle Master" level="9" />
+			<select type="Archetype Feature" name="Combat Superiority (Level 13)" supports="Maneuver,Battle Master" level="13" />
+			<select type="Archetype Feature" name="Combat Superiority (Level 17)" supports="Maneuver,Battle Master" level="17" />
+		</rules>
+	</element>
+
+	<element name="Skirmisher’s Stealth" type="Class Feature" source="Unearthed Arcana: Ranger" id="ID_WOTC_UA20150909_CLASSFEATURE_RANGER_SKIRMISHERS_STEALTH">
+		<description>
+			<p>Beginning at 2nd level, you combine speed and stealth in combat to make yourself hard to pin down. You are difficult to detect even if you attack or otherwise take actions that would normally reveal your presence.</p>
+			<p class="indent">At the start of your turn, pick a creature you are hidden from. You remain hidden from that creature during your turn, regardless of your actions or the actions of other creatures. As a bonus action at the end of your turn, you can make a Dexterity (Stealth) check to hide again if you fulfill the conditions needed to hide. Otherwise, creatures are aware of you at the end of your turn.</p>
+		</description>
+		<sheet>
+			<description>At the start of your turn, pick a creature you are hidden from. You remain hidden from that creature during your turn, regardless of your actions or the actions of other creatures. As a bonus action at the end of your turn, you can make a Dexterity (Stealth) check to hide again if you fulfill the conditions needed to hide. Otherwise, creatures are aware of you at the end of your turn.</description>
+		</sheet>
+	</element>
+
+    <element name="Spellcasting (Enhanced)" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_SPELLCASTING">
+        <description>
+            <p>By the time you reach 2nd level, you have learned to use the magical essence of nature to cast spells, much as a druid does. See chapter 10 for the general rules of spellcasting and chapter 11 for the ranger spell list.</p>
+            <h5>SPELL SLOTS</h5>
+            <p>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell’s level or higher. You regain all expended spell slots when you finish a long rest.</p>
+            <p class="indent">For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot.</p>
+            <h5>SPELLS KNOWN OF 1ST LEVEL AND HIGHER</h5>
+            <p>You know two 1st-level spells of your choice from the ranger spell list.</p>
+            <p class="indent">The Spells Known column of the Ranger table shows when you learn more ranger spells of your choice. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</p>
+            <p class="indent">Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots.</p>
+            <h5>SPELLCASTING ABILITY</h5>
+            <p>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</p>
+            <p class="indent">
+                <b>Spell save DC = 8</b> + your proficiency bonus + your Wisdom modifier
+            </p>
+            <p class="indent">
+                <b>Spell attack modifier =</b> your proficiency bonus + your Wisdom modifier
+            </p>
+            <h5>SPELL VERSATILITY</h5>
+            <p>Whenever you finish a long rest, you can replace one spell you learned from this Spellcasting feature with another spell from the ranger spell list. The new spell must be the same level as the spell you replace.</p>
+            <h5>SPELLCASTING FOCUS</h5>
+            <p>You can use a druidic focus as a spellcasting focus for your ranger spells. See chapter 5, “Equipment,” of the <i>Player’s Handbook</i> for a list of things that count as druidic focuses.</p>
+            <h5>RANGER SPELLS</h5>
+            <p>The following spells expand the ranger spell list:</p>
+            <table>
+                <thead>
+                    <tr><td>Spell Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>1st</td><td><s>aid</s><em>, entangle, searing smite</em></td></tr>
+                <tr><td>2nd</td><td><em>(aid), gust of wind, magic weapon, enhance ability, warding bond</em></td></tr>
+                <tr><td>3rd</td><td><em>blinding smite, meld into stone, revivify, tongues</em></td></tr>
+                <tr><td>4th</td><td><em>death ward, dominate beast</em></td></tr>
+                <tr><td>5th</td><td><em>awaken, greater restoration</em></td></tr>
+            </table>
+        </description>
+        <sheet>
+            <description>Whenever you finish a long rest, you can replace one spell you learned from this Spellcasting feature with another spell from the ranger spell list. The new spell must be the same level as the spell you replace.</description>
+        </sheet>
+        <spellcasting name="Ranger" ability="Wisdom" allowReplace="true">
+            <list>Ranger</list>
+        </spellcasting>
+        <rules>
+            <grant type="Grants" id="ID_INTERNAL_GRANT_MULTICLASS_SPELLCASTING_SLOTS_HALF" requirements="ID_INTERNAL_GRANT_MULTICLASS"/>
+
+            <stat name="ranger:spellcasting:slots:1" value="2" level="2" />
+            <stat name="ranger:spellcasting:slots:1" value="1" level="3" />
+            <stat name="ranger:spellcasting:slots:1" value="1" level="5" />
+            <stat name="ranger:spellcasting:slots:2" value="2" level="5" />
+            <stat name="ranger:spellcasting:slots:2" value="1" level="7" />
+            <stat name="ranger:spellcasting:slots:3" value="2" level="9" />
+            <stat name="ranger:spellcasting:slots:3" value="1" level="11" />
+            <stat name="ranger:spellcasting:slots:4" value="1" level="13" />
+            <stat name="ranger:spellcasting:slots:4" value="1" level="15" />
+            <stat name="ranger:spellcasting:slots:4" value="1" level="17" />
+            <stat name="ranger:spellcasting:slots:5" value="1" level="17" />
+            <stat name="ranger:spellcasting:slots:5" value="1" level="19" />
+
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="2" number="2" spellcasting="Ranger"/>
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="3" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="5" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="7" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="9" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="11" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="13" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="15" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="17" spellcasting="Ranger" />
+            <select type="Spell" name="Spellcasting (Ranger)" supports="$(spellcasting:list),$(spellcasting:slots)" level="19" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <element name="Expanded Spell List" type="Grants" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_SPELLCASTING_EXPAND">
+        <description>
+            <p>The following spells expand the ranger spell list:</p>
+            <table>
+                <thead>
+                    <tr><td>Spell Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>1st</td><td><em>aid, entangle, searing smite</em></td></tr>
+                <tr><td>2nd</td><td><em>gust of wind, magic weapon, enhance ability, warding bond</em></td></tr>
+                <tr><td>3rd</td><td><em>blinding smite, meld into stone, revivify, tongues</em></td></tr>
+                <tr><td>4th</td><td><em>death ward, dominate beast</em></td></tr>
+                <tr><td>5th</td><td><em>awaken, greater restoration</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <spellcasting name="Ranger" extend="true">
+            <extend>ID_PHB_SPELL_AID</extend>
+            <extend>ID_PHB_SPELL_ENTANGLE</extend>
+            <extend>ID_PHB_SPELL_SEARING_SMITE</extend>
+            <extend>ID_PHB_SPELL_GUST_OF_THE_WIND</extend>
+            <extend>ID_PHB_SPELL_MAGIC_WEAPON</extend>
+            <extend>ID_PHB_SPELL_ENHANCE_ABILITY</extend>
+            <extend>ID_PHB_SPELL_WARDING_BOND</extend>
+            <extend>ID_PHB_SPELL_BLINDING_SMITE</extend>
+            <extend>ID_PHB_SPELL_MELD_INTO_STONE</extend>
+            <extend>ID_PHB_SPELL_REVIVIFY</extend>
+            <extend>ID_PHB_SPELL_TONGUES</extend>
+            <extend>ID_PHB_SPELL_DEATH_WARD</extend>
+            <extend>ID_PHB_SPELL_DOMINATE_BEAST</extend>
+            <extend>ID_PHB_SPELL_AWAKEN</extend>
+            <extend>ID_PHB_SPELL_GREATER_RESTORATION</extend>
+        </spellcasting>
+    </element>
+
+    <!-- 5th Class Features GRANTS (currently none) -->
+
+    <!-- 5th Class Features -->
+    <element name="Ranger Archetype" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_RANGER_ARCHETYPE">
+        <description>
+            <p>At 3rd level, you choose an archetype that you strive to emulate: Hunter or Beast Master, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 7th, 11th, and 15th level.</p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype" name="5th Class Feature (Ranger Archetype)" supports="Ranger Archetype Constructor" />
+        </rules>
+    </element>
+
+    <!-- 6th Class Feature GRANTS -->
+    <element name="Primeval Awareness" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_PRIMEVAL_AWARENESS">
+        <supports>Ranger Constructor, 6th Class Feature</supports>
+        <description>
+            <p>Beginning at 3rd level, you can use your action and expend one ranger spell slot to focus your awareness on the region around you. For 1 minute per level of the spell slot you expend, you can sense whether the following types of creatures are present within 1 mile of you (or within up to 6 miles if you are in your favored terrain): aberrations, celestials, dragons, elementals, fey, fiends, and undead. This feature doesn’t reveal the creatures’ location or number.</p>
+        </description>
+        <sheet display="false">
+            <description>You can use your action and expend one ranger spell slot to focus your awareness on the region around you.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS" />
+        </rules>
+    </element>
+	<element name="Poultices" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_POULTICES_GRANTS">
+        <supports>Ranger Constructor, 6th Class Feature</supports>
+		<description>
+			<p>At 3rd level, you can create special herbal poultices that have healing power comparable to some potions. You can spend 1 hour gathering herbs and preparing herbal poultices using treated bandages to create a number of such poultices equal to your Wisdom modifier (minimum 1). You can carry a number of poultices at one time equal to your Wisdom modifier (minimum 1). The poultices you create cannot be applied by anyone but you. After 24 hours, any poultices that you have not used lose their potency.</p>
+			<p class="indent">If you spend 1 minute applying one of your poultices to a wounded humanoid creature, thereby expending its use, that creature regains 1d6 hit points for every two ranger levels you have (rounded up).</p>
+		</description>
+        <sheet display="false">
+			<description>You can spend 1 hour gathering herbs and preparing herbal poultices using treated bandages to create a number of such poultices equal to {{poultices:produce and carry}}. You can carry a number of poultices at one time equal to {{poultices:produce and carry}}. The poultices you create cannot be applied by anyone but you. After 24 hours, any poultices that you have not used lose their potency. If you spend 1 minute applying one of your poultices to a wounded humanoid creature, thereby expending its use, that creature regains {{poultices:dice amount}}d6 hit points.</description>
+		</sheet>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_POULTICES" />
+		</rules>
+	</element>
+    <element name="Primeval Awareness" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_PRIMEVAL_AWARENESS">
+        <supports>Ranger Constructor, 6th Class Feature</supports>
+        <description>
+            <p>Beginning at 3rd level, your mastery of ranger lore allows you to establish a powerful link to beasts and to the land around you.</p>
+            <p class="indent">You have innate ability to communicate with beasts, and they recognize you as a kindred spirit. Through sounds and gestures, you can communicate simple ideas to a beast as an action, and can read its basic mood and intent. You learn its emotional state, whether it is affected by magic of any sort, it's short-term needs (such as food and safety), and actions you can take (if any) to persuade it to not attack.</p>
+            <p class="indent">You cannot use this ability against a creature that you have attacked within the past 10 minutes.</p>
+            <p class="indent">Additionally, you can attune your senses to determine if any of your favored enemies lurk nearby. By spending 1 uninterrupted minute in concentration (as if you were concentrating on a spell), you can sense whether any of your favored enemies are present within 5 miles of you. This feature reveals which of your favored enemies are present, their numbers, and the creatures' general direction and distance (in miles) from you.</p>
+            <p class="indent">If there are multiple groups of your favored enemies within range, you learn this information for each group.</p>
+        </description>
+        <sheet display="false">
+            <description>Through sounds and gestures, you can communicate simple ideas to a beast as an action, and can read its basic mood and intent. You learn its emotional state, whether it is affected by magic of any sort, it's short-term needs (such as food and safety), and actions you can take (if any) to persuade it to not attack. You cannot use this ability against a creature that you have attacked within the past 10 minutes. Additionally, By spending 1 uninterrupted minute in concentration (as if you were concentrating on a spell), you can sense whether any of your favored enemies are present within 5 miles of you. This feature reveals which of your favored enemies are present, their numbers, and the creatures' general direction and distance (in miles) from you. If there are multiple groups of your favored enemies within range, you learn this information for each group.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS" />
+        </rules>
+    </element>
+
+    <element name="Primal Awareness" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_PRIMAL_AWARENESS">
+        <supports>Ranger Constructor, 6th Class Feature</supports>
+        <description>
+            <p>You can focus your awareness through the interconnections of nature: you learn additional spells when you reach certain levels in this class if you don’t already know them, as shown in the Primal Awareness Spells table. These spells don’t count against the number of ranger spells you know.</p>
+            <h5>Primal Awareness Spells</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spell</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>detect magic, speak with animals</em></td></tr>
+                <tr><td>5th</td><td><em>beast sense, locate animals or plants</em></td></tr>
+                <tr><td>9th</td><td><em>speak with plants</em></td></tr>
+                <tr><td>13th</td><td><em>locate creature</em></td></tr>
+                <tr><td>17th</td><td><em>commune with nature</em></td></tr>
+            </table>
+            <p class="indent">You can cast each of these spells once without expending a spell slot. Once you cast a spell in this way, you can’t do so again until you finish a long rest.</p>
+        </description>
+        <sheet display="false">
+            <description>You learn additional spells when you reach certain levels in this class if you don’t already know them, as shown in the Primal Awareness Spells table. You can cast each of these spells once without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_PRIMAL_AWARENESS" />
+        </rules>
+    </element>
+
+    <!-- 6th Class Features -->
+    <element name="Primeval Awareness" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS">
+        <description>
+            <p>Beginning at 3rd level, you can use your action and expend one ranger spell slot to focus your awareness on the region around you. For 1 minute per level of the spell slot you expend, you can sense whether the following types of creatures are present within 1 mile of you (or within up to 6 miles if you are in your favored terrain): aberrations, celestials, dragons, elementals, fey, fiends, and undead. This feature doesn’t reveal the creatures’ location or number.</p>
+        </description>
+        <sheet action="Action" >
+            <description>For 1 minute per level of the spell slot you expend, you can sense whether the following types of creatures are present within 1 mile of you (or within up to 6 miles if you are in your favored terrain): aberrations, celestials, dragons, elementals, fey, fiends, and undead. This feature doesn’t reveal the creatures’ location or number.</description>
+        </sheet>
+    </element>
+
+	<element name="Poultices" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_POULTICES">
+		<description>
+			<p>At 3rd level, you can create special herbal poultices that have healing power comparable to some potions. You can spend 1 hour gathering herbs and preparing herbal poultices using treated bandages to create a number of such poultices equal to your Wisdom modifier (minimum 1). You can carry a number of poultices at one time equal to your Wisdom modifier (minimum 1). The poultices you create cannot be applied by anyone but you. After 24 hours, any poultices that you have not used lose their potency.</p>
+			<p class="indent">If you spend 1 minute applying one of your poultices to a wounded humanoid creature, thereby expending its use, that creature regains 1d6 hit points for every two ranger levels you have (rounded up).</p>
+		</description>
+		<sheet>
+			<description>You can spend 1 hour gathering herbs and preparing herbal poultices using treated bandages to create a number of such poultices equal to {{poultices:produce and carry}}. You can carry a number of poultices at one time equal to {{poultices:produce and carry}}. The poultices you create cannot be applied by anyone but you. After 24 hours, any poultices that you have not used lose their potency. If you spend 1 minute applying one of your poultices to a wounded humanoid creature, thereby expending its use, that creature regains {{poultices:dice amount}}d6 hit points.</description>
+		</sheet>
+		<rules>
+			<stat name="poultices:produce and carry" value="wisdom:modifier" bonus="base"/>
+			<stat name="poultices:produce and carry" value="1" bonus="base"/>
+			<stat name="poultices:dice amount" value="level:ranger constructor constructor:half:up" bonus="base"/>
+		</rules>
+	</element>
+
+    <element name="Primeval Awareness" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS">
+        <description>
+            <p>Beginning at 3rd level, your mastery of ranger lore allows you to establish a powerful link to beasts and to the land around you.</p>
+            <p class="indent">You have innate ability to communicate with beasts, and they recognize you as a kindred spirit. Through sounds and gestures, you can communicate simple ideas to a beast as an action, and can read its basic mood and intent. You learn its emotional state, whether it is affected by magic of any sort, it's short-term needs (such as food and safety), and actions you can take (if any) to persuade it to not attack.</p>
+            <p class="indent">You cannot use this ability against a creature that you have attacked within the past 10 minutes.</p>
+            <p class="indent">Additionally, you can attune your senses to determine if any of your favored enemies lurk nearby. By spending 1 uninterrupted minute in concentration (as if you were concentrating on a spell), you can sense whether any of your favored enemies are present within 5 miles of you. This feature reveals which of your favored enemies are present, their numbers, and the creatures' general direction and distance (in miles) from you.</p>
+            <p class="indent">If there are multiple groups of your favored enemies within range, you learn this information for each group.</p>
+        </description>
+        <sheet>
+            <description>Through sounds and gestures, you can communicate simple ideas to a beast as an action, and can read its basic mood and intent. You learn its emotional state, whether it is affected by magic of any sort, it's short-term needs (such as food and safety), and actions you can take (if any) to persuade it to not attack. You cannot use this ability against a creature that you have attacked within the past 10 minutes. Additionally, By spending 1 uninterrupted minute in concentration (as if you were concentrating on a spell), you can sense whether any of your favored enemies are present within 5 miles of you. This feature reveals which of your favored enemies are present, their numbers, and the creatures' general direction and distance (in miles) from you. If there are multiple groups of your favored enemies within range, you learn this information for each group.</description>
+        </sheet>
+    </element>
+
+    <element name="Primal Awareness" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_PRIMAL_AWARENESS">
+        <description>
+            <p>You can focus your awareness through the interconnections of nature: you learn additional spells when you reach certain levels in this class if you don’t already know them, as shown in the Primal Awareness Spells table. These spells don’t count against the number of ranger spells you know.</p>
+            <h5>Primal Awareness Spells</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spell</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>detect magic, speak with animals</em></td></tr>
+                <tr><td>5th</td><td><em>beast sense, locate animals or plants</em></td></tr>
+                <tr><td>9th</td><td><em>speak with plants</em></td></tr>
+                <tr><td>13th</td><td><em>locate creature</em></td></tr>
+                <tr><td>17th</td><td><em>commune with nature</em></td></tr>
+            </table>
+            <p class="indent">You can cast each of these spells once without expending a spell slot. Once you cast a spell in this way, you can’t do so again until you finish a long rest.</p>
+        </description>
+        <sheet usage="1/Long Rest">
+            <description>You learn additional spells when you reach certain levels in this class if you don’t already know them, as shown in the Primal Awareness Spells table. You can cast each of these spells once without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" />
+            <grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_ANIMALS" />
+            <grant type="Spell" id="ID_PHB_SPELL_BEAST_SENSE" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_LOCATE_ANIMALS_OR_PLANTS" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_PLANTS" level="9" />
+            <grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" level="13" />
+            <grant type="Spell" id="ID_PHB_SPELL_COMMUNE_WITH_NATURE" level="17" />
+        </rules>
+    </element>
+
+    <!-- 7th Class Feature GRANTS -->
+	<element name="Ability Score Improvement (Ranger)" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_ASI">
+        <supports>Ranger Constructor, 7th Class Feature</supports>
+		<description>
+			<p>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.</p>
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_ASI" />
+		</rules>
+	</element>
+
+    <!-- 7th Class Features -->
+	<element name="Ability Score Improvement (Ranger)" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_ASI">
+		<description>
+			<p>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.</p>
+		</description>
+		<sheet display="false" />
+		<rules>
+			<!-- <grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_ASI_4_RANGER" level="4" requirements="!ID_INTERNAL_OPTION_ALLOW_FEATS" />
+			<grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_ASI_8_RANGER" level="8" requirements="!ID_INTERNAL_OPTION_ALLOW_FEATS" />
+			<grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_ASI_12_RANGER" level="12" requirements="!ID_INTERNAL_OPTION_ALLOW_FEATS" />
+			<grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_ASI_16_RANGER" level="16" requirements="!ID_INTERNAL_OPTION_ALLOW_FEATS" />
+			<grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_ASI_19_RANGER" level="19" requirements="!ID_INTERNAL_OPTION_ALLOW_FEATS" /> -->
+			<select type="Class Feature" name="Improvement Option (Ranger 4)" supports="Improvement Option,Ranger,4" level="4" />
+			<select type="Class Feature" name="Improvement Option (Ranger 8)" supports="Improvement Option,Ranger,8" level="8" />
+			<select type="Class Feature" name="Improvement Option (Ranger 12)" supports="Improvement Option,Ranger,12" level="12" />
+			<select type="Class Feature" name="Improvement Option (Ranger 16)" supports="Improvement Option,Ranger,16" level="16" />
+			<select type="Class Feature" name="Improvement Option (Ranger 19)" supports="Improvement Option,Ranger,19" level="19" />
+		</rules>
+	</element>
+
+    <!-- 8th Class Feature GRANTS -->
+	<element name="Extra Attack" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_EXTRA_ATTACK">
+        <supports>Ranger Constructor, 8th Class Feature</supports>
+		<description>
+			<p>Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.</p>
+		</description>
+		<sheet display="false">
+			<description>You can attack twice, instead of once, whenever you take the Attack action on your turn.</description>
+		</sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_EXTRA_ATTACK" />
+        </rules>
+	</element>
+    <element name="Coordinated Attack" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_COORDINATED_ATTACK">
+        <supports>Ranger Constructor, 8th Class Feature</supports>
+        <description>
+            <p>Beginning at 5th level, you and your animal companion form a more potent fighting team. When you use the Attack action on your turn, if your companion can see you, it can use its reaction to make a melee attack.</p>
+        </description>
+		<sheet display="false">
+            <description>When you use the Attack action on your turn, if your companion can see you, it can use its reaction to make a melee attack.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_COORDINATED_ATTACK" />
+        </rules>
+    </element>
+
+    <!-- 8th Class Features -->
+	<element name="Extra Attack" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_EXTRA_ATTACK">
+		<description>
+			<p>Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.</p>
+		</description>
+		<sheet>
+			<description>You can attack twice, instead of once, whenever you take the Attack action on your turn.</description>
+		</sheet>
+        <rules>
+            <stat name="extra attack:count" value="2" level="5" bonus="extra attack" />
+        </rules>
+	</element>
+
+    <element name="Coordinated Attack" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_COORDINATED_ATTACK">
+        <description>
+            <p>Beginning at 5th level, you and your animal companion form a more potent fighting team. When you use the Attack action on your turn, if your companion can see you, it can use its reaction to make a melee attack.</p>
+        </description>
+        <sheet>
+            <description>When you use the Attack action on your turn, if your companion can see you, it can use its reaction to make a melee attack.</description>
+        </sheet>
+    </element>
+
+    <!-- 9th Class Feature GRANTS -->
+    <element name="Greater Favored Enemy" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_GREATER_FAVORED_ENEMY">
+        <supports>Ranger Constructor, 9th Class Feature</supports>
+        <description>
+            <p>At 6th level, you are ready to hunt even deadlier game. Choose a type of greater favored enemy: abberations, celestials, constructs, dragons, elementals, fiends, or giants. You gain all the benefits against this chosen enemy that you normally gain against your favored enemy, including additional language. Your bonus to damage rolls against all your favored enemies increases to +4.</p>
+            <p class="indent">Additionally, you have advantage on saving throws against the spells and abilities used by greater favored enemy.</p>
+        </description>
+        <sheet display="false">
+            <description>Additionally to the bonus from Favored Enemy, you also have advantage on saving throws against the spells and abilities used by greater favored enemy.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_GREATER_FAVORED_ENEMY" />
+        </rules>
+    </element>
+
+    <!-- 9th Class Features -->
+    <element name="Greater Favored Enemy" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_GREATER_FAVORED_ENEMY">
+        <description>
+            <p>At 6th level, you are ready to hunt even deadlier game. Choose a type of greater favored enemy: abberations, celestials, constructs, dragons, elementals, fiends, or giants. You gain all the benefits against this chosen enemy that you normally gain against your favored enemy, including additional language. Your bonus to damage rolls against all your favored enemies increases to +4.</p>
+            <p class="indent">Additionally, you have advantage on saving throws against the spells and abilities used by greater favored enemy.</p>
+        </description>
+        <sheet>
+            <description>Your bonus to damage rolls against all your favored enemies increases to +4. Additionally to the bonus from Favored Enemy, you also have advantage on saving throws against the spells and abilities used by greater favored enemy. You also have advantage on Survival checks to track your favored enemies, as well as on Intelligence checks to recall information about them.</description>
+        </sheet>
+        <rules>
+            <select type="Class Feature" name="Greater Favored Enemy" supports="Greater Favored Enemy" level="6" />
+            <select type="Language" name="Language (Greater Favored Enemy)" level="6" />
+        </rules>
+    </element>
+
+    <!-- 10th Class Feature GRANTS -->
+    <element name="Land’s Stride" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_LANDS_STRIDE">
+        <supports>Ranger Constructor, 10th Class Feature</supports>
+        <description>
+            <p>Starting at 8th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.</p>
+            <p class="indent">In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell.</p>
+        </description>
+        <sheet display="false">
+            <description>Moving through nonmagical difficult terrain costs you no extra movement. In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_LANDS_STRIDE" />
+        </rules>
+    </element>
+    <element name="Fleet of Foot" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_FLEET_OF_FOOT">
+        <supports>Ranger Constructor, 10th Class Feature</supports>
+        <description>
+            <p>Beginning at 8th level, you can use the Dash action as a bonus action on your turn.</p>
+        </description>
+        <sheet display="false">
+            <description>You can use the Dash action as a bonus action on your turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FLEET_OF_FOOT" />
+        </rules>
+    </element>
+
+    <!-- 10th Class Features -->
+    <element name="Land’s Stride" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_LANDS_STRIDE">
+        <description>
+            <p>Starting at 8th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.</p>
+            <p class="indent">In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell.</p>
+        </description>
+        <sheet>
+            <description>Moving through nonmagical difficult terrain costs you no extra movement. In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell.</description>
+        </sheet>
+    </element>
+
+    <element name="Fleet of Foot" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_FLEET_OF_FOOT">
+        <description>
+            <p>Beginning at 8th level, you can use the Dash action as a bonus action on your turn.</p>
+        </description>
+        <sheet>
+            <description>You can use the Dash action as a bonus action on your turn.</description>
+        </sheet>
+    </element>
+
+    <!-- 11th Class Feature GRANTS -->
+	<element name="Natural Antivenom" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_NATURAL_ANTIVENOM">
+        <supports>Ranger Constructor, 11th Class Feature</supports>
+		<description>
+			<p>Starting at 9th level, you have advantage on saving throws against poison and have resistance to poison damage. Additionally, you can use one of your poultices to cure one poison effect on the creature you are applying it to, in addition to restoring hit points.</p>
+		</description>
+		<sheet display="false">
+			<description>You have advantage on saving throws against poison and you can use one of your poultices to cure one poison effect on the creature you are applying it to, in addition to restoring hit points.</description>
+		</sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_NATURAL_ANTIVENOM" />
+        </rules>
+    </element>
+
+    <!-- 11th Class Features -->
+	<element name="Natural Antivenom" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_NATURAL_ANTIVENOM">
+		<description>
+			<p>Starting at 9th level, you have advantage on saving throws against poison and have resistance to poison damage. Additionally, you can use one of your poultices to cure one poison effect on the creature you are applying it to, in addition to restoring hit points.</p>
+		</description>
+		<sheet>
+			<description>You have advantage on saving throws against poison and you can use one of your poultices to cure one poison effect on the creature you are applying it to, in addition to restoring hit points.</description>
+		</sheet>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_POISON" />
+		</rules>
+	</element>
+
+    <!-- 12th Class Feature GRANTS -->
+    <element name="Hide in Plain Sight" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_HIDE_IN_PLAIN_SIGHT">
+        <supports>Ranger Constructor, 12th Class Feature</supports>
+        <description>
+            <p>Starting at 10th level, you can spend 1 minute creating camouflage for yourself. You must have access to fresh mud, dirt, plants, soot, and other naturally occurring materials with which to create your camouflage.</p>
+            <p class="indent">Once you are camouflaged in this way, you can try to hide by pressing yourself up against a solid surface, such as a tree or wall, that is at least as tall and wide as you are. You gain a +10 bonus to Dexterity (Stealth) checks as long as you remain there without moving or taking actions. Once you move or take an action or a reaction, you must camouflage yourself again to gain this benefit.</p>
+        </description>
+        <sheet display="false">
+            <description>You can spend 1 minute creating camouflage for yourself. You gain a +10 bonus to Stealth checks as long as you remain there without moving or taking actions.</description>
+        </sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT" />
+        </rules>
+    </element>
+    <element name="Hide in Plain Sight" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_CONSTRUCTOR_HIDE_IN_PLAIN_SIGHT">
+        <supports>Ranger Constructor, 12th Class Feature</supports>
+        <description>
+            <p>Starting at 10th level, you can remain perfectly still for long periods of time to set up ambushes.</p>
+            <p class="indent">When you attempt to hide on your turn you can opt to not move on that turn. If you avoid moving, creatures that attempt to detect you take a -10 penalty to their Wisdom (Perception) checks until the start of your next turn. You lose this benefit if you move or fall prone, either voluntarily or because of some external effect. You are still automatically detected if any effect or action cause you to no longer be hidden.</p>
+            <p class="indent">If you are still hidden on your next turn, you can continue to remain motionless and gain this benefit until you are detected.</p>
+        </description>
+        <sheet display="false">
+            <description>When you attempt to hide on your turn you can opt to not move on that turn. If you avoid moving, creatures that attempt to detect you take a -10 penalty to their Wisdom (Perception) checks until the start of your next turn. You lose this benefit if you move or fall prone, either voluntarily or because of some external effect. You are still automatically detected if any effect or action cause you to no longer be hidden. If you are still hidden on your next turn, you can continue to remain motionless and gain this benefit until you are detected.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT" />
+        </rules>
+    </element>
+    <element name="Fade Away" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_CONSTRUCTOR_FADE_AWAY">
+        <supports>Ranger Constructor, 12th Class Feature</supports>
+        <description>
+            <p>You can use a bonus action to magically become invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet display="false">
+            <description>You can become magically invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FADE_AWAY" />
+        </rules>
+    </element>
+
+    <!-- 12th Class Features -->
+    <element name="Hide in Plain Sight" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT">
+        <description>
+            <p>Starting at 10th level, you can spend 1 minute creating camouflage for yourself. You must have access to fresh mud, dirt, plants, soot, and other naturally occurring materials with which to create your camouflage.</p>
+            <p class="indent">Once you are camouflaged in this way, you can try to hide by pressing yourself up against a solid surface, such as a tree or wall, that is at least as tall and wide as you are. You gain a +10 bonus to Dexterity (Stealth) checks as long as you remain there without moving or taking actions. Once you move or take an action or a reaction, you must camouflage yourself again to gain this benefit.</p>
+        </description>
+        <sheet>
+            <description>You can spend 1 minute creating camouflage for yourself. You gain a +10 bonus to Stealth checks as long as you remain there without moving or taking actions.</description>
+        </sheet>
+    </element>
+
+    <element name="Hide in Plain Sight" type="Class Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT">
+        <description>
+            <p>Starting at 10th level, you can remain perfectly still for long periods of time to set up ambushes.</p>
+            <p class="indent">When you attempt to hide on your turn you can opt to not move on that turn. If you avoid moving, creatures that attempt to detect you take a -10 penalty to their Wisdom (Perception) checks until the start of your next turn. You lose this benefit if you move or fall prone, either voluntarily or because of some external effect. You are still automatically detected if any effect or action cause you to no longer be hidden.</p>
+            <p class="indent">If you are still hidden on your next turn, you can continue to remain motionless and gain this benefit until you are detected.</p>
+        </description>
+        <sheet>
+            <description>When you attempt to hide on your turn you can opt to not move on that turn. If you avoid moving, creatures that attempt to detect you take a -10 penalty to their Wisdom (Perception) checks until the start of your next turn. You lose this benefit if you move or fall prone, either voluntarily or because of some external effect. You are still automatically detected if any effect or action cause you to no longer be hidden. If you are still hidden on your next turn, you can continue to remain motionless and gain this benefit until you are detected.</description>
+        </sheet>
+    </element>
+
+    <element name="Fade Away" type="Class Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_CLASSFEATURE_RANGER_FADE_AWAY">
+        <description>
+            <p>You can use a bonus action to magically become invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet usage="1/Rest" action="Bonus Action">
+            <description>You can become magically invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</description>
+        </sheet>
+    </element>
+
+    <!-- 13th Class Feature GRANTS -->
+	<element name="Call Natural Allies" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_CALL_NATURAL_ALLIES">
+        <supports>Ranger Constructor, 13th Class Feature</supports>
+		<description>
+			<p>Starting at 13th level, when you are in an area of your favored terrain, you can call natural creatures from that terrain to fight on your behalf, using your attunement to the natural world to convince them to aid you. The DM chooses beasts appropriate to the terrain to come to your aid from among those that could hear you and that are within 1 mile of you, in one of the following groups:</p>
+			<ul>
+				<li>One beast of challenge rating 2 or lower</li>
+				<li>Two beasts of challenge rating 1 or lower</li>
+				<li>Four beasts of challenge rating 1/2 or lower</li>
+				<li>Eight beasts of challenge rating 1/4 or lower</li>
+			</ul>
+			<p>These beasts approach you from their current location, and will fight alongside you, attacking any creatures that are hostile to you. They are friendly to you and your comrades, and you roll initiative for the called creatures as a group, which takes its own turns. The DM has the creatures’ statistics.</p>
+			<p class="indent">After 1 hour, these beasts return to their previous location. Once you use this feature, you cannot use it again in the same general area for 24 hours, since the same animals will not repeatedly heed your call.</p>
+		</description>
+        <sheet display="false">
+			<description>When you are in an area of your favored terrain, you can call natural creatures from that terrain to fight on your behalf, using your attunement to the natural world to convince them to aid you. The DM chooses beasts appropriate to the terrain to come to your aid from among those that could hear you and that are within 1 mile of you, in one of the following groups: One beast of challenge rating 2 or lower; Two beasts of challenge rating 1 or lower; Four beasts of challenge rating 1/2 or lower; Eight beasts of challenge rating 1/4 or lower. They are friendly to you and your comrades, and you roll initiative for the called creatures as a group, which takes its own turns. After 1 hour, these beasts return to their previous location. Once you use this feature, you cannot use it again in the same general area for 24 hours.</description>
+		</sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CALL_NATURAL_ALLIES" />
+        </rules>
+    </element>
+
+    <!-- 13th Class Features -->
+	<element name="Call Natural Allies" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CALL_NATURAL_ALLIES">
+		<description>
+			<p>Starting at 13th level, when you are in an area of your favored terrain, you can call natural creatures from that terrain to fight on your behalf, using your attunement to the natural world to convince them to aid you. The DM chooses beasts appropriate to the terrain to come to your aid from among those that could hear you and that are within 1 mile of you, in one of the following groups:</p>
+			<ul>
+				<li>One beast of challenge rating 2 or lower</li>
+				<li>Two beasts of challenge rating 1 or lower</li>
+				<li>Four beasts of challenge rating 1/2 or lower</li>
+				<li>Eight beasts of challenge rating 1/4 or lower</li>
+			</ul>
+			<p>These beasts approach you from their current location, and will fight alongside you, attacking any creatures that are hostile to you. They are friendly to you and your comrades, and you roll initiative for the called creatures as a group, which takes its own turns. The DM has the creatures’ statistics.</p>
+			<p class="indent">After 1 hour, these beasts return to their previous location. Once you use this feature, you cannot use it again in the same general area for 24 hours, since the same animals will not repeatedly heed your call.</p>
+		</description>
+		<sheet>
+			<description>When you are in an area of your favored terrain, you can call natural creatures from that terrain to fight on your behalf, using your attunement to the natural world to convince them to aid you. The DM chooses beasts appropriate to the terrain to come to your aid from among those that could hear you and that are within 1 mile of you, in one of the following groups: One beast of challenge rating 2 or lower; Two beasts of challenge rating 1 or lower; Four beasts of challenge rating 1/2 or lower; Eight beasts of challenge rating 1/4 or lower. They are friendly to you and your comrades, and you roll initiative for the called creatures as a group, which takes its own turns. After 1 hour, these beasts return to their previous location. Once you use this feature, you cannot use it again in the same general area for 24 hours.</description>
+		</sheet>
+	</element>
+
+    <!-- 14th Class Feature GRANTS -->
+    <element name="Vanish" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_VANISH">
+        <supports>Ranger Constructor, 14th Class Feature</supports>
+        <description>
+            <p>Starting at 14th level, you can use the Hide action as a bonus action on your turn. Also, you can’t be tracked by nonmagical means, unless you choose to leave a trail.</p>
+        </description>
+        <sheet display="false">
+            <description>You can use the Hide action as a bonus action on your turn. Also, you can’t be tracked by nonmagical means, unless you choose to leave a trail.</description>
+        </sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_VANISH" />
+        </rules>
+    </element>
+
+    <!-- 14th Class Features -->
+    <element name="Vanish" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_VANISH">
+        <description>
+            <p>Starting at 14th level, you can use the Hide action as a bonus action on your turn. Also, you can’t be tracked by nonmagical means, unless you choose to leave a trail.</p>
+        </description>
+        <sheet>
+            <description>You can use the Hide action as a bonus action on your turn. Also, you can’t be tracked by nonmagical means, unless you choose to leave a trail.</description>
+        </sheet>
+    </element>
+
+    <!-- 15th Class Feature GRANTS -->
+	<element name="Relentless" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_CONSTRUCTOR_RELENTLESS">
+        <supports>Ranger Constructor, 15th Class Feature</supports>
+		<description>
+			<p>Starting at 17th level, when you roll initiative and have no superiority dice remaining, you regain 1 superiority die.</p>
+		</description>
+        <sheet display="false">
+			<description>When you roll initiative and have no superiority dice remaining, you regain 1 superiority die.</description>
+		</sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_RELENTLESS" />
+        </rules>
+    </element>
+
+    <!-- 15th Class Features -->
+	<element name="Relentless" type="Class Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_CLASSFEATURE_RANGER_RELENTLESS">
+		<description>
+			<p>Starting at 17th level, when you roll initiative and have no superiority dice remaining, you regain 1 superiority die.</p>
+		</description>
+		<sheet>
+			<description>When you roll initiative and have no superiority dice remaining, you regain 1 superiority die.</description>
+		</sheet>
+	</element>
+
+    <!-- 16th Class Feature GRANTS -->
+    <element name="Feral Senses" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_FERAL_SENSES">
+        <supports>Ranger Constructor, 16th Class Feature</supports>
+        <description>
+            <p>At 18th level, you gain preternatural senses that help you fight creatures you can’t see. When you attack a creature you can’t see, your inability to see it doesn’t impose disadvantage on your attack rolls against it.</p>
+            <p class="indent">You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn’t hidden from you and you aren’t blinded or deafened.</p>
+        </description>
+        <sheet display="false">
+            <description>When you attack a creature you can’t see, your inability to see it doesn’t impose disadvantage on your attack rolls against it. You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn’t hidden from you and you aren’t blinded or deafened.</description>
+        </sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FERAL_SENSES" />
+        </rules>
+    </element>
+
+    <!-- 16th Class Features -->
+    <element name="Feral Senses" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_FERAL_SENSES">
+        <description>
+            <p>At 18th level, you gain preternatural senses that help you fight creatures you can’t see. When you attack a creature you can’t see, your inability to see it doesn’t impose disadvantage on your attack rolls against it.</p>
+            <p class="indent">You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn’t hidden from you and you aren’t blinded or deafened.</p>
+        </description>
+        <sheet>
+            <description>When you attack a creature you can’t see, your inability to see it doesn’t impose disadvantage on your attack rolls against it. You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn’t hidden from you and you aren’t blinded or deafened.</description>
+        </sheet>
+    </element>
+
+    <!-- 17th Class Feature GRANTS -->
+    <element name="Foe Slayer" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_CONSTRUCTOR_FOE_SLAYER">
+        <supports>Ranger Constructor, 17th Class Feature</supports>
+        <description>
+            <p>At 20th level, you become an unparalleled hunter of your enemies. Once on each of your turns, you can add your Wisdom modifier to the attack roll or the damage roll of an attack you make against one of your favored enemies. You can choose to use this feature before or after the roll, but before any effects of the roll are applied.</p>
+        </description>
+        <sheet display="false">
+            <description>Once on each of your turns, you can add your Wisdom modifier to the attack roll or the damage roll of an attack you make against one of your favored enemies. You can choose to use this feature before or after the roll, but before any effects of the roll are applied.</description>
+        </sheet>
+		<rules>
+            <grant type="Class Feature" id="ID_WOTC_CLASSFEATURE_RANGER_FOE_SLAYER" />
+        </rules>
+    </element>
+
+    <!-- 17th Class Features -->
+    <element name="Foe Slayer" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_FOE_SLAYER">
+        <description>
+            <p>At 20th level, you become an unparalleled hunter of your enemies. Once on each of your turns, you can add your Wisdom modifier to the attack roll or the damage roll of an attack you make against one of your favored enemies. You can choose to use this feature before or after the roll, but before any effects of the roll are applied.</p>
+        </description>
+        <sheet usage="1/Turn">
+            <description>You can add your Wisdom modifier to the attack roll or the damage roll of an attack you make against one of your favored enemies. You can choose to use this feature before or after the roll, but before any effects of the roll are applied.</description>
+        </sheet>
+        <rules>
+            <stat name="foe slayer:attack" value="wisdom:modifier" />
+            <stat name="foe slayer:damage" value="wisdom:modifier" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor -->
+    <element name="Ranger Archetype Constructor" type="Archetype" source="Player’s Handbook" id="ID_WOTC_RANGER_ARCHETYPE_CONSTRUCTOR">
+        <supports>Ranger Archetype Constructor</supports>
+        <description>
+            <p><b>Description of Hunter Ranger Archetype, doesn't include all possible features.</b></p>
+            <p>Emulating the Hunter archetype means accepting your place as a bulwark between civilization and the terrors of the wilderness. As you walk the Hunter’s path, you learn specialized techniques for fighting the threats you face, from rampaging ogres and hordes of orcs to towering giants and terrifying dragons.</p>
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY" />
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS" />
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_MULTIATTACK" />
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE" />
+        </description>
+        <sheet alt="Constructed Archetype">
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype Feature" name="1st Archetype Feature" supports="Ranger Archetype Constructor, 1st Archetype Feature" level="3" />
+            <select type="Archetype Feature" name="2nd Archetype Feature" supports="Ranger Archetype Constructor, 2nd Archetype Feature" level="3" optional="true" />
+            <select type="Archetype Feature" name="3rd Archetype Feature" supports="Ranger Archetype Constructor, 3rd Archetype Feature" level="3" optional="true" />
+            <select type="Archetype Feature" name="4th Archetype Feature" supports="Ranger Archetype Constructor, 4th Archetype Feature" level="7" />
+            <select type="Archetype Feature" name="5th Archetype Feature" supports="Ranger Archetype Constructor, 5th Archetype Feature" level="11" />
+            <select type="Archetype Feature" name="6th Archetype Feature" supports="Ranger Archetype Constructor, 6th Archetype Feature" level="15" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 1st Archetype Feature GRANTS -->
+    <element name="Hunter’s Prey" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_HUNTERS_PREY">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Colossus Slayer.</span>Your tenacity can wear down the most potent foes. When you hit a creature with a weapon attack, the creature takes an extra 1d8 damage if it’s below its hit point maximum. You can deal this extra damage only once per turn.
+                <br/>
+                <span class="feature">Giant Killer.</span>When a Large or larger creature within 5 feet of you hits or misses you with an attack, you can use your reaction to attack that creature immediately after its attack, provided that you can see the creature.
+                <br/>
+                <span class="feature">Horde Breaker.</span>Once on each of your turns when you make a weapon attack, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon.
+                <br/>
+            </p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+		<rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY" />
+        </rules>
+    </element>
+    <element name="Ranger’s Companion" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_RANGERS_COMPANION">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain a beast companion that accompanies you on your adventures and is trained to fight alongside you. Choose a beast that is no larger than Medium and that has a challenge rating of 1/4 or lower (appendix D presents statistics for the hawk, mastiff, and panther as examples). Add your proficiency bonus to the beast’s AC, attack rolls, and damage rolls, as well as to any saving throws and skills it is proficient in. Its hit point maximum equals its normal maximum or four times your ranger level, whichever is higher.</p>
+            <p class="indent">The beast obeys your commands as best as it can. It takes its turn on your initiative, though it doesn’t take an action unless you command it to. On your turn, you can verbally command the beast where to move (no action required by you). You can use your action to verbally command it to take the Attack, Dash, Disengage, Dodge, or Help action. Once you have the Extra Attack feature, you can make one weapon attack yourself when you command the beast to take the Attack action.</p>
+            <p class="indent">While traveling through your favored terrain with only the beast, you can move stealthily at a normal pace.</p>
+            <p class="indent">If the beast dies, you can obtain another one by spending 8 hours magically bonding with another beast that isn’t hostile to you, either the same type of beast as before or a different one.</p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_RANGERS_COMPANION" />
+        </rules>
+    </element>
+    <element name="Deep Stalker Magic" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_DEEP_STALKER_DEEP_STALKER_MAGIC">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain darkvision out to range of 90 feet. If you already have darkvision, you increase its range by 30 feet. </p>
+            <p class="indent">You also gain access to additional spells when you reach certain levels in this class, as shown in the Deep Stalker Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>       
+            <h5>DEEP STALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>disguise self</em></td></tr>
+                <tr><td>5rd</td><td><em>rope trick</em></td></tr>
+                <tr><td>9th</td><td><em>glyph of warding</em></td></tr>
+                <tr><td>13th</td><td><em>greater invisibility</em></td></tr>
+                <tr><td>17th</td><td><em>seeming</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_DEEP_STALKER_DEEP_STALKER_MAGIC" />
+        </rules>
+    </element>
+    <element name="Animal Companion" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_BEAST_ANIMAL_COMPANION">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you learn to use your magic to create a powerful bond with a creature of the natural world.</p>
+            <p class="indent">Within 8 hours of word and the expenditure of 50 gp worth of rare herbs and fine food, you call faorth an animal from the wilderness to serve as your faithful companion. You normally select your companion from among the following animals: an ape, a black bear, a boar, a giant badger, a giant weasel, a mule, a panther, or a wolf. However, you DM might pick one of these animals for you, based on the surrounding terrain and on what types of creatures would logically be present in the area.</p>
+            <p class="indent">At the end of the 8 hours, your animal companion appears and gains all the benefits of your Companion's Bond ability. You can have only one animal companion at a time.</p>
+            <p class="indent">If your animal companion is ever slain, the magical bond you share allows you to return it to life. With 8 hours of work and the expenditure of 25 gp worth of rare herbs and fine food, you call forth your companion's spirit and use your magic to create a new body for it. You can return an animal companion to life this manner even if you do not possess any part of its body.</p>
+            <p class="indent">If you use this ability to return a former animal to life while you have a current animal companion, your current companion leaves you and is replaced by the restored companion.</p>
+            <h5>COMPANION'S BOND</h5>
+            <p>Your aninmal companion gains a variety of benefits while it is linked to you.</p>
+            <p class="indent">The animal companion loses its Multiattack action, if it has one.</p>
+            <p class="indent">The companion obeys your commands as best it can. It rolls for initiative like any other creature, but you determine its actions, decisions, attitudes, and so on. If you are incapacitated or absent, your companion acts on its own.</p>
+            <p class="indent">Your animal companion has abilities and game statistics determined in part by your level. Your companion uses your proficiency bonus rather than its own. An animal companion add its proficiency bonus to AC, skills, saving throws, attack bonus, and damage rolls.</p>
+            <p class="indent">Your animal companion gains proficiency in two skills of your choice. It also becomes proficient with all saving throws.</p>
+            <p class="indent">For each level you gain after 3rd, your animal companion gains an additional hit die and increases its hit points accordingly.</p>
+            <p class="indent">Whenever you gain the Ability Score Improvement class feature, your companion's abilities also improve. Your companion can increase one ability score of your choice by 2, or it can increase two ability scores of your choice by 1. As normal, your companion can't increase an ability score above 20 using this feature.</p>
+            <p class="indent">Your animal companion gains the benefits of your Favored Enemy feature, and of your Greater Enemy feature when you gain that feature at 6th level. It uses the favored enemies you selected for those features.</p>
+            <p class="indent">When using your Natural Explorer feature, you and your animal companion can both move stealthily at a normal pace.</p>
+            <p class="indent">Your companion shares your alignment, and has a personality trait and a flaw that you can roll for or select from the tables below. Your companion shares your ideal and its bond is always, "The ranger who travels with me is a beloved companion for whom i would gladly give my life".</p>
+			<table>
+				<thead>
+					<tr><td>d6</td><td>Trait</td></tr>
+				</thead>
+				<tr><td>1</td><td>I'm dauntless in the face of adversity.</td></tr>
+				<tr><td>2</td><td>Threaten my friends, threaten me.</td></tr>
+				<tr><td>3</td><td>I stay on alert so others can rest.</td></tr>
+				<tr><td>4</td><td>People see an animal and underestinate me. I use that to my advantage.</td></tr>
+				<tr><td>5</td><td>I have a knack for showing up in the nick of time.</td></tr>
+				<tr><td>6</td><td>I put my friends' need before my own in all things.</td></tr>
+			</table>
+            <table>
+				<thead>
+					<tr><td>d6</td><td>Flaw</td></tr>
+				</thead>
+				<tr><td>1</td><td>If there's food left unattended, i'll eat it.</td></tr>
+				<tr><td>2</td><td>I growl at strangers, and all people except my ranger are strangers to me.</td></tr>
+				<tr><td>3</td><td>Any time is a good time for a belly rub.</td></tr>
+				<tr><td>4</td><td>I'm deathly afraid of water.</td></tr>
+				<tr><td>5</td><td>My idea of hello is a flurry of licks to the face.</td></tr>
+				<tr><td>6</td><td>I jump on creatures to tell them how much i love them.</td></tr>
+			</table>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_ANIMAL_COMPANION" />
+        </rules>
+    </element>
+    <element name="Ranger Companion Options" type="Archetype Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_RANGER_COMPANION_OPTIONS">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>While wandering the wilds, a ranger encounters many sorts of animals, some of which the ranger might befriend. This friendship can arise from successful use of the Animal Handling skill or the <i>animal friendship</i> spell. If the resulting bond is strong enough, the animal might join the ranger on adventures.</p>
+            <p class="indent">A ranger who has the Beast Master archetype can form an even stronger bond, feeling almost like a sibling to an animal. A special type of beast awaits a Beast Master in the wilds, a creature whose lineage stretches back to the beginnings of the world: a primal beast known as a Beast of the Air or a Beast of the Earth. Such a creature seeks out the type of companionship that a Beast Master offers, ready for the two of them to battle the imbalances in the natural world.</p>
+            <p class="indent">The primal beast is a special creature that a Beast Master can choose for the Ranger’s Companion feature. When choosing such a creature, you decide whether it is a Beast of the Air or the Earth, and you determine its appearance. Stories describe primal beasts that mystically change form to align with the spirit of their companion.</p>
+            <p class="indent">When a primal beast is met apart from a Beast Master, the creature takes the form a regular beast of challenge rating 1/4 or lower, as determined by the DM.</p>
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_RANGERS_COMPANION" />
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20191104_ARCHETYPE_FEATURE_RANGER_RANGER_COMPANION_OPTIONS" />
+        </rules>
+    </element>
+    <element name="Gloom Stalker Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_GLOOM_STALKER_MAGIC">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Gloom Stalker Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>       
+            <h5>GLOOM STALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>disguise self</em></td></tr>
+                <tr><td>5rd</td><td><em>rope trick</em></td></tr>
+                <tr><td>9th</td><td><em>fear</em></td></tr>
+                <tr><td>13th</td><td><em>greater invisibility</em></td></tr>
+                <tr><td>17th</td><td><em>seeming</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_GLOOM_STALKER_MAGIC" />
+        </rules>
+    </element>
+    <element name="Monster Slayer Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_SLAYER_MONSTER_SLAYER_MAGIC">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Monster Slayer Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>
+            <h5>MONSTER SLAYER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>protection from evil and good</em></td></tr>
+                <tr><td>5rd</td><td><em>zone of truth</em></td></tr>
+                <tr><td>9th</td><td><em>magic circle</em></td></tr>
+                <tr><td>13th</td><td><em>banishment</em></td></tr>
+                <tr><td>17th</td><td><em>hold monster</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_MONSTER_SLAYER_MAGIC" />
+        </rules>
+    </element>
+    <element name="Horizon Walker Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_MAGIC">
+        <supports>Ranger Archetype Constructor, 1st Archetype Feature</supports>
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Horizon Walker Spells table. The spell counts as a ranger spell for you, but it doesn’t count against the number of ranger spells you know.</p>
+            <h5>HORIZON WALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr>
+                        <td>Ranger Level</td><td>Spell</td>
+                    </tr>
+                </thead>
+                <tr><td>3rd</td><td><em>protection from evil and good</em></td></tr>
+                <tr><td>5th</td><td><em>misty step</em></td></tr>
+                <tr><td>9th</td><td><em>haste</em></td></tr>
+                <tr><td>13th</td><td><em>banishment</em></td></tr>
+                <tr><td>17th</td><td><em>teleportation circle</em></td></tr>
+            </table>            
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_MAGIC" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 1st Archetype Features -->
+    <element name="Hunter’s Prey" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY">
+        <description>
+            <p>At 3rd level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Colossus Slayer.</span>Your tenacity can wear down the most potent foes. When you hit a creature with a weapon attack, the creature takes an extra 1d8 damage if it’s below its hit point maximum. You can deal this extra damage only once per turn.
+                <br/>
+                <span class="feature">Giant Killer.</span>When a Large or larger creature within 5 feet of you hits or misses you with an attack, you can use your reaction to attack that creature immediately after its attack, provided that you can see the creature.
+                <br/>
+                <span class="feature">Horde Breaker.</span>Once on each of your turns when you make a weapon attack, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon.
+                <br/>
+            </p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype Feature" name="Hunter’s Prey" supports="Hunters Pray" />
+        </rules>
+    </element>
+
+    <element name="Ranger’s Companion" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_RANGERS_COMPANION">
+        <description>
+            <p>At 3rd level, you gain a beast companion that accompanies you on your adventures and is trained to fight alongside you. Choose a beast that is no larger than Medium and that has a challenge rating of 1/4 or lower (appendix D presents statistics for the hawk, mastiff, and panther as examples). Add your proficiency bonus to the beast’s AC, attack rolls, and damage rolls, as well as to any saving throws and skills it is proficient in. Its hit point maximum equals its normal maximum or four times your ranger level, whichever is higher.</p>
+            <p class="indent">The beast obeys your commands as best as it can. It takes its turn on your initiative, though it doesn’t take an action unless you command it to. On your turn, you can verbally command the beast where to move (no action required by you). You can use your action to verbally command it to take the Attack, Dash, Disengage, Dodge, or Help action. Once you have the Extra Attack feature, you can make one weapon attack yourself when you command the beast to take the Attack action.</p>
+            <p class="indent">While traveling through your favored terrain with only the beast, you can move stealthily at a normal pace.</p>
+            <p class="indent">If the beast dies, you can obtain another one by spending 8 hours magically bonding with another beast that isn’t hostile to you, either the same type of beast as before or a different one.</p>
+        </description>
+        <sheet>
+            <description>The beast obeys your commands as best as it can. It takes its turn on your initiative, though it doesn’t take an action unless you command it to. On your turn, you can verbally command the beast where to move (no action required by you). You can use your action to verbally command it to take the Attack, Dash, Disengage, Dodge, or Help action. Once you have the Extra Attack feature, you can make one weapon attack yourself when you command the beast to take the Attack action.
+            While traveling through your favored terrain with only the beast, you can move stealthily at a normal pace.
+            If the beast dies, you can obtain another one by spending 8 hours magically bonding with another beast that isn’t hostile to you, either the same type of beast as before or a different one.</description>
+        </sheet>
+        <rules>
+            <select type="Companion" name="Ranger’s Companion" supports="Beast,(Tiny||Small||Medium),(1/4||1/8||0)" />
+            <stat name="companion:ac" value="proficiency" />
+            <stat name="companion:attack" value="proficiency" />
+            <stat name="companion:damage" value="proficiency" />
+            <!-- 4x ranger level -->
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+
+            <stat name="companion:hp:max" value="_alternative:hp:max" bonus="base" />
+        </rules>
+    </element>
+
+    <element name="Deep Stalker Magic" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_DEEP_STALKER_DEEP_STALKER_MAGIC">
+        <description>
+            <p>At 3rd level, you gain darkvision out to range of 90 feet. If you already have darkvision, you increase its range by 30 feet. </p>
+            <p class="indent">You also gain access to additional spells when you reach certain levels in this class, as shown in the Deep Stalker Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>       
+            <h5>DEEP STALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>disguise self</em></td></tr>
+                <tr><td>5rd</td><td><em>rope trick</em></td></tr>
+                <tr><td>9th</td><td><em>glyph of warding</em></td></tr>
+                <tr><td>13th</td><td><em>greater invisibility</em></td></tr>
+                <tr><td>17th</td><td><em>seeming</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Vision" id="ID_VISION_DARKVISION" />
+            <grant type="Spell" name="ID_PHB_SPELL_DISGUISE_SELF" level="3" spellcasting="Ranger"/>
+            <grant type="Spell" name="ID_PHB_SPELL_ROPE_TRICK" level="5" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_GLYPH_OF_WARDING" level="9" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_GREATER_INVISIBILITY" level="13" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_SEEMING" level="17" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <element name="Animal Companion" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_ANIMAL_COMPANION">
+        <description>
+            <p>At 3rd level, you learn to use your magic to create a powerful bond with a creature of the natural world.</p>
+            <p class="indent">Within 8 hours of word and the expenditure of 50 gp worth of rare herbs and fine food, you call faorth an animal from the wilderness to serve as your faithful companion. You normally select your companion from among the following animals: an ape, a black bear, a boar, a giant badger, a giant weasel, a mule, a panther, or a wolf. However, you DM might pick one of these animals for you, based on the surrounding terrain and on what types of creatures would logically be present in the area.</p>
+            <p class="indent">At the end of the 8 hours, your animal companion appears and gains all the benefits of your Companion's Bond ability. You can have only one animal companion at a time.</p>
+            <p class="indent">If your animal companion is ever slain, the magical bond you share allows you to return it to life. With 8 hours of work and the expenditure of 25 gp worth of rare herbs and fine food, you call forth your companion's spirit and use your magic to create a new body for it. You can return an animal companion to life this manner even if you do not possess any part of its body.</p>
+            <p class="indent">If you use this ability to return a former animal to life while you have a current animal companion, your current companion leaves you and is replaced by the restored companion.</p>
+            <h5>COMPANION'S BOND</h5>
+            <p>Your aninmal companion gains a variety of benefits while it is linked to you.</p>
+            <p class="indent">The animal companion loses its Multiattack action, if it has one.</p>
+            <p class="indent">The companion obeys your commands as best it can. It rolls for initiative like any other creature, but you determine its actions, decisions, attitudes, and so on. If you are incapacitated or absent, your companion acts on its own.</p>
+            <p class="indent">Your animal companion has abilities and game statistics determined in part by your level. Your companion uses your proficiency bonus rather than its own. An animal companion add its proficiency bonus to AC, skills, saving throws, attack bonus, and damage rolls.</p>
+            <p class="indent">Your animal companion gains proficiency in two skills of your choice. It also becomes proficient with all saving throws.</p>
+            <p class="indent">For each level you gain after 3rd, your animal companion gains an additional hit die and increases its hit points accordingly.</p>
+            <p class="indent">Whenever you gain the Ability Score Improvement class feature, your companion's abilities also improve. Your companion can increase one ability score of your choice by 2, or it can increase two ability scores of your choice by 1. As normal, your companion can't increase an ability score above 20 using this feature.</p>
+            <p class="indent">Your animal companion gains the benefits of your Favored Enemy feature, and of your Greater Enemy feature when you gain that feature at 6th level. It uses the favored enemies you selected for those features.</p>
+            <p class="indent">When using your Natural Explorer feature, you and your animal companion can both move stealthily at a normal pace.</p>
+            <p class="indent">Your companion shares your alignment, and has a personality trait and a flaw that you can roll for or select from the tables below. Your companion shares your ideal and its bond is always, "The ranger who travels with me is a beloved companion for whom i would gladly give my life".</p>
+			<table>
+				<thead>
+					<tr><td>d6</td><td>Trait</td></tr>
+				</thead>
+				<tr><td>1</td><td>I'm dauntless in the face of adversity.</td></tr>
+				<tr><td>2</td><td>Threaten my friends, threaten me.</td></tr>
+				<tr><td>3</td><td>I stay on alert so others can rest.</td></tr>
+				<tr><td>4</td><td>People see an animal and underestinate me. I use that to my advantage.</td></tr>
+				<tr><td>5</td><td>I have a knack for showing up in the nick of time.</td></tr>
+				<tr><td>6</td><td>I put my friends' need before my own in all things.</td></tr>
+			</table>
+            <table>
+				<thead>
+					<tr><td>d6</td><td>Flaw</td></tr>
+				</thead>
+				<tr><td>1</td><td>If there's food left unattended, i'll eat it.</td></tr>
+				<tr><td>2</td><td>I growl at strangers, and all people except my ranger are strangers to me.</td></tr>
+				<tr><td>3</td><td>Any time is a good time for a belly rub.</td></tr>
+				<tr><td>4</td><td>I'm deathly afraid of water.</td></tr>
+				<tr><td>5</td><td>My idea of hello is a flurry of licks to the face.</td></tr>
+				<tr><td>6</td><td>I jump on creatures to tell them how much i love them.</td></tr>
+			</table>
+        </description>
+        <sheet>
+            <!-- right now i can only implement this feature through description, this will be changed later then appropriate rules are added to the Aurora -->
+            <description>An animal companion adds your proficiency bonus to the following areas: AC, skills, saving throws, attack bonus and damage rolls. Your companion gains proficiency in two skills of your choice, it also becomes proficient with all saving throws. The animal loses its Multiattack action, if it has one. For every level you gain after 3rd your animal companion gains an additional hit die and increases its hit points accordingly. Whenever you gain Ability Score Improvement class feature, your companion can also increase one ability score of your choice by 2, or two ability scores of your choice by 1.</description>
+        </sheet>
+        <rules>
+            <!-- these are rules for the original Beast Master Archetype, i deleted HP rules, because they don't match this feature
+            to do: companion skills
+            to do: companion saving throws
+            to do: companion ASI
+            to do: cut companion's Multiattack
+            to do: companion HP rules-->
+    	    <select type="Companion" name="Ranger’s Companion" supports="Beast,(Tiny||Small||Medium),(1/4||1/8||0)" />
+    	    <stat name="companion:ac" value="proficiency" />
+    	    <stat name="companion:attack" value="proficiency" />
+    	    <stat name="companion:damage" value="proficiency" />
+        </rules>
+    </element>
+
+    <element name="Ranger Companion Options" type="Archetype Feature" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_ARCHETYPE_FEATURE_RANGER_RANGER_COMPANION_OPTIONS">
+        <description>
+            <p>While wandering the wilds, a ranger encounters many sorts of animals, some of which the ranger might befriend. This friendship can arise from successful use of the Animal Handling skill or the <i>animal friendship</i> spell. If the resulting bond is strong enough, the animal might join the ranger on adventures.</p>
+            <p class="indent">A ranger who has the Beast Master archetype can form an even stronger bond, feeling almost like a sibling to an animal. A special type of beast awaits a Beast Master in the wilds, a creature whose lineage stretches back to the beginnings of the world: a primal beast known as a Beast of the Air or a Beast of the Earth. Such a creature seeks out the type of companionship that a Beast Master offers, ready for the two of them to battle the imbalances in the natural world.</p>
+            <p class="indent">The primal beast is a special creature that a Beast Master can choose for the Ranger’s Companion feature. When choosing such a creature, you decide whether it is a Beast of the Air or the Earth, and you determine its appearance. Stories describe primal beasts that mystically change form to align with the spirit of their companion.</p>
+            <p class="indent">When a primal beast is met apart from a Beast Master, the creature takes the form a regular beast of challenge rating 1/4 or lower, as determined by the DM.</p>
+            <div element="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_RANGERS_COMPANION" />
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Companion" name="Ranger’s Companion" supports="Beast,(Tiny||Small||Medium),(1/4||1/8||0)|ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR|ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH" />
+            <stat name="companion:ac" value="proficiency" />
+            <stat name="companion:attack" value="proficiency" />
+            <stat name="companion:damage" value="proficiency" />
+            <!-- 4x ranger level -->
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+
+            <stat name="companion:hp:max" value="_alternative:hp:max" bonus="base" />
+        </rules>
+    </element>
+
+    <element name="Gloom Stalker Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_GLOOM_STALKER_MAGIC">
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Gloom Stalker Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>       
+            <h5>GLOOM STALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>disguise self</em></td></tr>
+                <tr><td>5rd</td><td><em>rope trick</em></td></tr>
+                <tr><td>9th</td><td><em>fear</em></td></tr>
+                <tr><td>13th</td><td><em>greater invisibility</em></td></tr>
+                <tr><td>17th</td><td><em>seeming</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Spell" name="ID_PHB_SPELL_DISGUISE_SELF" level="3" spellcasting="Ranger"/>
+            <grant type="Spell" name="ID_PHB_SPELL_ROPE_TRICK" level="5" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_FEAR" level="9" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_GREATER_INVISIBILITY" level="13" spellcasting="Ranger" />
+            <grant type="Spell" name="ID_PHB_SPELL_SEEMING" level="17" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <element name="Monster Slayer Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_MONSTER_SLAYER_MAGIC">
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Monster Slayer Spells table. The spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.</p>
+            <h5>MONSTER SLAYER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>protection from evil and good</em></td></tr>
+                <tr><td>5rd</td><td><em>zone of truth</em></td></tr>
+                <tr><td>9th</td><td><em>magic circle</em></td></tr>
+                <tr><td>13th</td><td><em>banishment</em></td></tr>
+                <tr><td>17th</td><td><em>hold monster</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" level="3" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_ZONE_OF_TRUTH" level="5" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_MAGIC_CIRCLE" level="9" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_BANISHMENT" level="13" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_HOLD_MONSTER" level="17" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <element name="Horizon Walker Magic" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_MAGIC">
+        <description>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Horizon Walker Spells table. The spell counts as a ranger spell for you, but it doesn’t count against the number of ranger spells you know.</p>
+            <h5>HORIZON WALKER SPELLS</h5>
+            <table>
+                <thead>
+                    <tr>
+                        <td>Ranger Level</td><td>Spell</td>
+                    </tr>
+                </thead>
+                <tr><td>3rd</td><td><em>protection from evil and good</em></td></tr>
+                <tr><td>5th</td><td><em>misty step</em></td></tr>
+                <tr><td>9th</td><td><em>haste</em></td></tr>
+                <tr><td>13th</td><td><em>banishment</em></td></tr>
+                <tr><td>17th</td><td><em>teleportation circle</em></td></tr>
+            </table>            
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" level="3" spellcasting="Ranger"/>
+            <grant type="Spell" id="ID_PHB_SPELL_MISTY_STEP" level="5" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_HASTE" level="9" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_BANISHMENT" level="13" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" level="17" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 2nd Archetype Feature GRANTS -->
+    <element name="Underdark Scout" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_DEEP_STALKER_UNDERDARK_SCOUT">
+        <supports>Ranger Archetype Constructor, 2nd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you master the art of the ambush. At the start of your first turn of each combat, your walking speed increases by 10 feet, which lasts until the end of that turn. If you take the Attack action on that turn, you can make one additional weapon attack as part of that action.</p>
+            <p class="indent">You are also adept at evading creatures that rely on darkvision. Such creatures gain no benefit when attempting to detect you in dark and dim conditions. Additionally, when the DM determines if you can hide from a creature, that creature gains no benefit from its darkvision.</p>
+        </description>
+        <sheet display="false">
+            <description>At the start of your first combat turn, your walking speed increases by 10ft until the end of that turn. If you attack that turn, make one additional weapon attack. Creatures that rely on darkvision don't get benefit trying to detect you in dim or dark conditions and if you trying to hide.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_DEEP_STALKER_UNDERDARK_SCOUT" />
+        </rules>
+    </element>
+    <element name="Dread Ambusher" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_DREAD_AMBUSHER">
+        <supports>Ranger Archetype Constructor, 2nd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you master the art of the ambush. You can give yourself a bonus to your initiative rolls equal to your Wisdom modifier.</p>
+            <p class="indent">At the start of your first turn of each combat, your walking speed increases by 10 feet, which lasts until the end of that turn. If you take the Attack action on that turn, you can make one additional weapon attack as part of that action. If that attack hits, the target takes an extra 1d8 damage of the weapons damage type.</p>
+        </description>
+        <sheet display="false">
+            <description>At the start of your first turn, your walking speed increases by 10ft until the end of that turn. If you attack that turn, make one additional weapon attack. If it hits, the target takes an extra 1d8 damage.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_DREAD_AMBUSHER" />
+        </rules>
+    </element>
+    <element name="Hunter's Sense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_SLAYER_HUNTERS_SENSE">
+        <supports>Ranger Archetype Constructor, 2nd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain the ability to peer at a creature and magically discern how best to hurt it. As an action, choose one creature you can see within 60 feet of you. You immediately learn whether the creature has any damage immunities, resistances, or vulnerabilities and what they are. If the creature is hidden from divination magic, you sense that it has no damage immunities, resistances, or vulnerabilities.</p>
+            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses of it when you finish a long rest.</p>
+        </description>
+        <sheet display="false">
+            <description>Choose 1 creature wthin 60ft. You learn its damage immunities, resistances, or vulnerabilities, if it's hidden from divination magic, you sense it has none.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_HUNTERS_SENSE" />
+        </rules>
+    </element>
+    <element name="Detect Portal" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_DETECT_PORTAL">
+        <supports>Ranger Archetype Constructor, 2nd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain the ability to magically sense the presence of a planar portal. As an action, you detect the distance and direction to the closest planar portal within 1 mile of you.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+            <p class="indent">See the "Planar Travel" section in chapter 2 of the Dungeon Master’s Guide for examples of planar portals.</p>
+        </description>
+        <sheet display="false">
+            <description>You detect the distance and direction to the closest planar portal within 1 mile of you.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_DETECT_PORTAL" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 2nd Archetype Features -->
+    <element name="Underdark Scout" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_DEEP_STALKER_UNDERDARK_SCOUT">
+        <description>
+            <p>At 3rd level, you master the art of the ambush. At the start of your first turn of each combat, your walking speed increases by 10 feet, which lasts until the end of that turn. If you take the Attack action on that turn, you can make one additional weapon attack as part of that action.</p>
+            <p class="indent">You are also adept at evading creatures that rely on darkvision. Such creatures gain no benefit when attempting to detect you in dark and dim conditions. Additionally, when the DM determines if you can hide from a creature, that creature gains no benefit from its darkvision.</p>
+        </description>
+        <sheet>
+            <description>At the start of your first combat turn, your walking speed increases by 10ft until the end of that turn. If you attack that turn, make one additional weapon attack. Creatures that rely on darkvision don't get benefit trying to detect you in dim or dark conditions and if you trying to hide.</description>
+        </sheet>
+    </element>
+
+    <element name="Dread Ambusher" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_DREAD_AMBUSHER">
+        <description>
+            <p>At 3rd level, you master the art of the ambush. You can give yourself a bonus to your initiative rolls equal to your Wisdom modifier.</p>
+            <p class="indent">At the start of your first turn of each combat, your walking speed increases by 10 feet, which lasts until the end of that turn. If you take the Attack action on that turn, you can make one additional weapon attack as part of that action. If that attack hits, the target takes an extra 1d8 damage of the weapons damage type.</p>
+        </description>
+        <sheet>
+            <description>At the start of your first turn, your walking speed increases by 10ft until the end of that turn. If you attack that turn, make one additional weapon attack. If it hits, the target takes an extra 1d8 damage.</description>
+        </sheet>
+        <rules>
+            <stat name="initiative" value="wisdom:modifier" />
+        </rules>
+    </element>
+
+    <element name="Hunter's Sense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_HUNTERS_SENSE">
+        <description>
+            <p>At 3rd level, you gain the ability to peer at a creature and magically discern how best to hurt it. As an action, choose one creature you can see within 60 feet of you. You immediately learn whether the creature has any damage immunities, resistances, or vulnerabilities and what they are. If the creature is hidden from divination magic, you sense that it has no damage immunities, resistances, or vulnerabilities.</p>
+            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses of it when you finish a long rest.</p>
+        </description>
+        <sheet action="Action" usage="{{hunters sense:uses}}/Long Rest">
+            <description>Choose 1 creature wthin 60ft. You learn its damage immunities, resistances, or vulnerabilities, if it's hidden from divination magic, you sense it has none.</description>
+        </sheet>
+        <rules>
+            <stat name="hunters sense:uses" value="wisdom:modifier" />
+        </rules>
+    </element>
+
+    <element name="Detect Portal" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_DETECT_PORTAL">
+        <description>
+            <p>At 3rd level, you gain the ability to magically sense the presence of a planar portal. As an action, you detect the distance and direction to the closest planar portal within 1 mile of you.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+            <p class="indent">See the "Planar Travel" section in chapter 2 of the Dungeon Master’s Guide for examples of planar portals.</p>
+        </description>
+        <sheet action="Action" usage="1/Short Rest">
+            <description>You detect the distance and direction to the closest planar portal within 1 mile of you.</description>
+        </sheet>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 3rd Archetype Feature GRANTS -->
+    <element name="Umbral Sight" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_UMBRAL_SIGHT">
+        <supports>Ranger Archetype Constructor, 3rd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you gain darkvision out to a range of 60 feet. If you already have darkvision from your race, its range increases by 30 feet.</p>
+            <p class="indent">You are also adept at evading creatures that rely on darkvision. While in darkness, you are invisible to any creature that relies on darkvision to see you in that darkness.</p>
+        </description>
+        <sheet>
+            <description>While in darkness, you are invisible to any creature that relies on darkvision to see you in that darkness.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_UMBRAL_SIGHT" />
+        </rules>
+    </element>
+    <element name="Slayer's Prey" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_SLAYER_SLAYERS_PREY">
+        <supports>Ranger Archetype Constructor, 3rd Archetype Feature</supports>
+        <description>
+            <p>Starting at 3rd level, you can focus your ire on one foe, increasing the harm you inflict on it. As a bonus action, you designate one creature you can see within 60 feet of you as the target of this feature. The first time each turn that you hit that target with a weapon attack, it takes an extra 1d6 damage from the weapon.</p>
+            <p class="indent">This benefit lasts until you finish a short or long rest. It ends early if you designate a different creature.</p>
+        </description>
+        <sheet action="Bonus Action">
+            <description>Designate 1 creature within 60ft, the first time each turn you hit that target with a weapon attack, it takes an extra 1d6 damage from the weapon. This benefit lasts until you finish a short or long rest. It ends early if you designate a different creature.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SLAYERS_PREY" />
+        </rules>
+    </element>
+    <element name="Planar Warrior" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_PLANAR_WARRIOR">
+        <supports>Ranger Archetype Constructor, 3rd Archetype Feature</supports>
+        <description>
+            <p>At 3rd level, you learn to draw on the energy of the multiverse to augment your attacks.</p>
+            <p class="indent">As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 1d8 force damage from the attack. When you reach 11th level in this class, the extra damage increases to 2d8.</p>
+        </description>
+        <sheet>
+            <description>As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 1d8 force damage from the attack.</description>
+            <description level="11">As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 2d8 force damage from the attack.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_PLANAR_WARRIOR" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 3rd Archetype Features -->
+    <element name="Umbral Sight" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_UMBRAL_SIGHT">
+        <description>
+            <p>At 3rd level, you gain darkvision out to a range of 60 feet. If you already have darkvision from your race, its range increases by 30 feet.</p>
+            <p class="indent">You are also adept at evading creatures that rely on darkvision. While in darkness, you are invisible to any creature that relies on darkvision to see you in that darkness.</p>
+        </description>
+        <sheet>
+            <description>While in darkness, you are invisible to any creature that relies on darkvision to see you in that darkness.</description>
+        </sheet>
+        <rules>
+            <grant type="Vision" id="ID_VISION_DARKVISION" />
+        </rules>
+    </element>
+
+    <element name="Slayer's Prey" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SLAYERS_PREY">
+        <description>
+            <p>Starting at 3rd level, you can focus your ire on one foe, increasing the harm you inflict on it. As a bonus action, you designate one creature you can see within 60 feet of you as the target of this feature. The first time each turn that you hit that target with a weapon attack, it takes an extra 1d6 damage from the weapon.</p>
+            <p class="indent">This benefit lasts until you finish a short or long rest. It ends early if you designate a different creature.</p>
+        </description>
+        <sheet action="Bonus Action">
+            <description>Designate 1 creature within 60ft, the first time each turn you hit that target with a weapon attack, it takes an extra 1d6 damage from the weapon. This benefit lasts until you finish a short or long rest. It ends early if you designate a different creature.</description>
+        </sheet>
+    </element>
+
+    <element name="Planar Warrior" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_PLANAR_WARRIOR">
+        <description>
+            <p>At 3rd level, you learn to draw on the energy of the multiverse to augment your attacks.</p>
+            <p class="indent">As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 1d8 force damage from the attack. When you reach 11th level in this class, the extra damage increases to 2d8.</p>
+        </description>
+        <sheet>
+            <description>As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 1d8 force damage from the attack.</description>
+            <description level="11">As a bonus action, choose one creature you can see within 30 feet of you. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes an extra 2d8 force damage from the attack.</description>
+        </sheet>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 4th Archetype Feature GRANTS -->
+    <element name="Defensive Tactics" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_DEFENSIVE_TACTICS">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>At 7th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Escape the Horde.</span>Opportunity attacks against you are made with disadvantage.
+                <br/>
+                <span class="feature">Multiattack Defense.</span>When a creature hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the turn.
+                <br/>
+                <span class="feature">Steel Will.</span>You have advantage on saving throws against being frightened.
+                <br/>
+            </p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS" />
+        </rules>
+    </element>
+    <element name="Exceptional Training" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_EXCEPTIONAL_TRAINING">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>Beginning at 7th level, on any of your turns when your beast companion doesn’t attack, you can use a bonus action to command the beast to take the Dash, Disengage, Dodge, or Help action on its turn.</p>
+        </description>
+        <sheet display="false">
+            <description>On any of your turns when your beast companion doesn’t attack, you can use a bonus action to command the beast to take the Dash, Disengage, Dodge, or Help action on its turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_EXCEPTIONAL_TRAINING" />
+        </rules>
+    </element>
+    <element name="Beast's Defence" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_BEAST_BEASTS_DEFENSE">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>At 7th level, while your companion can see you it has advantage on all saving throws.</p>
+        </description>
+        <sheet display="false">
+            <description>While your companion can see you it has advantage on all saving throws.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_BEASTS_DEFENSE" />
+        </rules>
+    </element>
+    <element name="Iron Mind" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_IRON_MIND">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>By 7th level, you have honed your ability to resist the mind—altering powers of your prey. You gain proficiency in Wisdom saving throws. If you already have this proficiency, you instead gain proficiency in Intelligence or Charisma saving throws (your choice).</p>
+        </description>
+        <sheet display="false"/>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_IRON_MIND" />
+        </rules>
+    </element>
+    <element name="Supernatural Defense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_SLAYER_SUPERNATURAL_DEFENSE">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>At 7th level, you gain extra resilience against your prey’s assaults on your mind and body. Whenever the target of your Slayer’s Prey forces you to make a saving throw and whenever you make an ability check to escape that targets grapple, add 1d6 to your roll.</p>
+        </description>
+        <sheet display="false">
+            <description>Whenever the target of your Slayer’s Prey forces you to make a saving throw and whenever you make an ability check to escape that targets grapple, add 1d6 to your roll.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SUPERNATURAL_DEFENSE" />
+        </rules>
+    </element>
+    <element name="Ethereal Step" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_ETHEREAL_STEP">
+        <supports>Ranger Archetype Constructor, 4th Archetype Feature</supports>
+        <description>
+            <p>At 7th level, you learn to step through the Ethereal Plane. As a bonus action, you can cast the <i>etherealness</i> spell with this feature, without expending a spell slot, but the spell ends at the end of the current turn.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet display="false">
+            <description>You can cast the etherealness spell with this feature, without expending a spell slot, but the spell ends at the end of the current turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_ETHEREAL_STEP" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 4th Archetype Features -->
+    <element name="Defensive Tactics" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS">
+        <description>
+            <p>At 7th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Escape the Horde.</span>Opportunity attacks against you are made with disadvantage.
+                <br/>
+                <span class="feature">Multiattack Defense.</span>When a creature hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the turn.
+                <br/>
+                <span class="feature">Steel Will.</span>You have advantage on saving throws against being frightened.
+                <br/>
+            </p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype Feature" name="Defensive Tactics" supports="Defensive Tactics" />
+        </rules>
+    </element>
+
+    <element name="Exceptional Training" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_EXCEPTIONAL_TRAINING">
+        <description>
+            <p>Beginning at 7th level, on any of your turns when your beast companion doesn’t attack, you can use a bonus action to command the beast to take the Dash, Disengage, Dodge, or Help action on its turn.</p>
+        </description>
+        <sheet>
+            <description>On any of your turns when your beast companion doesn’t attack, you can use a bonus action to command the beast to take the Dash, Disengage, Dodge, or Help action on its turn.</description>
+        </sheet>
+    </element>
+
+    <element name="Beast's Defence" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_BEASTS_DEFENSE">
+        <description>
+            <p>At 7th level, while your companion can see you it has advantage on all saving throws.</p>
+        </description>
+        <sheet>
+            <description>While your companion can see you it has advantage on all saving throws.</description>
+        </sheet>
+        <rules />
+    </element>
+
+    <element name="Iron Mind" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_IRON_MIND">
+        <description>
+            <p>By 7th level, you have honed your ability to resist the mind—altering powers of your prey. You gain proficiency in Wisdom saving throws. If you already have this proficiency, you instead gain proficiency in Intelligence or Charisma saving throws (your choice).</p>
+        </description>
+        <sheet display="false"/>
+        <rules>
+            <select type="Proficiency" name="Saving Throw Proficiency (Gloom Stalker)" supports="ID_PROFICIENCY_SAVINGTHROW_WISDOM|ID_PROFICIENCY_SAVINGTHROW_INTELLIGENCE|ID_PROFICIENCY_SAVINGTHROW_CHARISMA" default="ID_PROFICIENCY_SAVINGTHROW_WISDOM" />
+        </rules>
+    </element>
+
+    <element name="Supernatural Defense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SUPERNATURAL_DEFENSE">
+        <description>
+            <p>At 7th level, you gain extra resilience against your prey’s assaults on your mind and body. Whenever the target of your Slayer’s Prey forces you to make a saving throw and whenever you make an ability check to escape that targets grapple, add 1d6 to your roll.</p>
+        </description>
+        <sheet>
+            <description>Whenever the target of your Slayer’s Prey forces you to make a saving throw and whenever you make an ability check to escape that targets grapple, add 1d6 to your roll.</description>
+        </sheet>
+    </element>
+
+    <element name="Ethereal Step" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_HORIZON_WALKER_ETHEREAL_STEP">
+        <description>
+            <p>At 7th level, you learn to step through the Ethereal Plane. As a bonus action, you can cast the <i>etherealness</i> spell with this feature, without expending a spell slot, but the spell ends at the end of the current turn.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet action="Bonus Action" usage="1/Short Rest">
+            <description>You can cast the etherealness spell with this feature, without expending a spell slot, but the spell ends at the end of the current turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_ETHEREALNESS" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 5th Archetype Feature GRANTS -->
+    <element name="Multiattack" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_HUNTER_MULTIATTACK">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>At 11th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Volley.</span>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon’s range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target.
+                <br/>
+                <span class="feature">Whirlwind Attack.</span>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.
+                <br/>
+            </p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTER_MULTIATTACK" />
+        </rules>
+    </element>
+    <element name="Bestial Fury" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_BESTIAL_FURY">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>Starting at 11th level, your beast companion can make two attacks when you command it to use the Attack action.</p>
+        </description>
+        <sheet display="false">
+            <description>Your beast companion can make two attacks when you command it to use the Attack action.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_BESTIAL_FURY" />
+        </rules>
+    </element>
+    <element name="Storm of Claws and Fangs" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_BEAST_STORM_OF_CLAWS_AND_FANGS">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>Starting at 11th level, your companion can use its action to make a melee attack against each creature of its choice within 5 feet of it, with a separate attack for each target.</p>
+        </description>
+        <sheet display="false">
+            <description>Your companion can use its action to make a melee attack against each creature of its choice within 5 feet of it, with a separate attack for each target.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_STORM_OF_CLAWS_AND_FANGS" />
+        </rules>
+    </element>
+    <element name="Stalker's Flurry" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_STALKERS_FURY">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>At 11th level, you learn to attack with such unexpected speed that you can turn a miss into another strike. Once on each of your turns when you miss with a weapon attack, you can make another weapon attack as part of the same action.</p>
+        </description>
+        <sheet display="false">
+            <description>1/turn when you miss with a weapon attack, make another weapon attack as part of the same action.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_STALKERS_FURY" />
+        </rules>
+    </element>
+    <element name="Magic-user's Nemesis" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_MAGICUSERS_NEMESIS">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>At 11th level, you gain the ability to thwart someone else’s magic. When you see a creature casting a spell or teleporting within 60 feet of you, you can use your reaction to try to magically foil it. The creature must succeed on a Wisdom saving throw against your spell save DC, or its spell or teleport fails and is wasted.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet display="false">
+            <description>When you see a creature casting a spell or teleporting within 60ft, you can try to magically foil it. It makes a DC{{spellcasting:dc:wis}} Wisdom saving throw, or its spell or teleport fails and is wasted.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_STALKERS_FURY" />
+        </rules>
+    </element>
+    <element name="Distant Strike" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_DISTANT_STRIKE">
+        <supports>Ranger Archetype Constructor, 5th Archetype Feature</supports>
+        <description>
+            <p>At 11th level, you gain the ability to pass between the planes in the blink of an eye. When you take the Attack action, you can teleport up to 10 feet before each attack to an unoccupied space you can see.</p>
+            <p class="indent">If you attack at least two different creatures with the action, you can make one additional attack with it against a third creature.</p>
+        </description>
+        <sheet display="false">
+            <description>When you take the Attack action, you can teleport up to 10 feet before each attack to an unoccupied space you can see. If you attack at least two different creatures with the action, you can make one additional attack with it against a third creature.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_HORIZON_WALKER_DISTANT_STRIKE" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 5th Archetype Features -->
+    <element name="Multiattack" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTER_MULTIATTACK">
+        <description>
+            <p>At 11th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Volley.</span>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon’s range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target.
+                <br/>
+                <span class="feature">Whirlwind Attack.</span>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.
+                <br/>
+            </p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype Feature" name="Multiattack" supports="Multiattack" />
+        </rules>
+    </element>
+
+    <element name="Bestial Fury" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_BESTIAL_FURY">
+        <description>
+            <p>Starting at 11th level, your beast companion can make two attacks when you command it to use the Attack action.</p>
+        </description>
+        <sheet>
+            <description>Your beast companion can make two attacks when you command it to use the Attack action.</description>
+        </sheet>
+    </element>
+
+    <element name="Storm of Claws and Fangs" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_STORM_OF_CLAWS_AND_FANGS">
+        <description>
+            <p>Starting at 11th level, your companion can use its action to make a melee attack against each creature of its choice within 5 feet of it, with a separate attack for each target.</p>
+        </description>
+        <sheet>
+            <description>Your companion can use its action to make a melee attack against each creature of its choice within 5 feet of it, with a separate attack for each target.</description>
+        </sheet>
+    </element>
+
+    <element name="Stalker's Flurry" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_STALKERS_FURY">
+        <description>
+            <p>At 11th level, you learn to attack with such unexpected speed that you can turn a miss into another strike. Once on each of your turns when you miss with a weapon attack, you can make another weapon attack as part of the same action.</p>
+        </description>
+        <sheet>
+            <description>1/turn when you miss with a weapon attack, make another weapon attack as part of the same action.</description>
+        </sheet>
+    </element>
+
+    <element name="Magic-user's Nemesis" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_MAGICUSERS_NEMESIS">
+        <description>
+            <p>At 11th level, you gain the ability to thwart someone else’s magic. When you see a creature casting a spell or teleporting within 60 feet of you, you can use your reaction to try to magically foil it. The creature must succeed on a Wisdom saving throw against your spell save DC, or its spell or teleport fails and is wasted.</p>
+            <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
+        </description>
+        <sheet action="Reaction" usage="1/Short Rest">
+            <description>When you see a creature casting a spell or teleporting within 60ft, you can try to magically foil it. It makes a DC{{spellcasting:dc:wis}} Wisdom saving throw, or its spell or teleport fails and is wasted.</description>
+        </sheet>
+    </element>
+
+    <element name="Distant Strike" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_HORIZON_WALKER_DISTANT_STRIKE">
+        <description>
+            <p>At 11th level, you gain the ability to pass between the planes in the blink of an eye. When you take the Attack action, you can teleport up to 10 feet before each attack to an unoccupied space you can see.</p>
+            <p class="indent">If you attack at least two different creatures with the action, you can make one additional attack with it against a third creature.</p>
+        </description>
+        <sheet>
+            <description>When you take the Attack action, you can teleport up to 10 feet before each attack to an unoccupied space you can see. If you attack at least two different creatures with the action, you can make one additional attack with it against a third creature.</description>
+        </sheet>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 6th Archetype Feature GRANTS -->
+    <element name="Superior Hunter’s Defense" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_SUPERIOR_HUNTERS_DEFENSE">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>At 15th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Evasion.</span>You can nimbly dodge out of the way of certain area effects, such as a red dragon’s fiery breath or a lightning bolt spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.
+                <br/>
+                <span class="feature">Stand Against the Tide.</span>When a hostile creature misses you with a melee attack, you can use your reaction to force that creature to repeat the same attack against another creature (other than itself) of your choice.
+                <br/>
+                <span class="feature">Uncanny Dodge.</span>When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack’s damage against you.
+                <br/>
+            </p>
+        </description>
+        <sheet display="false">
+            <description></description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE" />
+        </rules>
+    </element>
+    <element name="Share Spells" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_CONSTRUCTOR_BEAST_SHARE_SPELLS">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>Beginning at 15th level, when you cast a spell targeting yourself, you can also affect your beast companion with the spell if the beast is within 30 feet of you.</p>
+        </description>
+        <sheet display="false">
+            <description>When you cast a spell targeting yourself, you can also affect your beast companion with the spell if the beast is within 30 feet of you.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_BEAST_SHARE_SPELLS" />
+        </rules>
+    </element>
+	<element name="Beastly Coordination" type="Archetype Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_RANGER_CONSTRUCTOR_ARCHETYPE_BEAST_MASTER_BEASTLY_COORDINATION">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+		<description>
+			<p>Beginning at 15th level, when an attacker that you can see hits your beast companion with an attack, you can call out a warning. If your beast companion can hear you, it can use its reaction to halve the attack’s damage against it.</p>
+		</description>
+        <sheet display="false">
+			<description>When an attacker that you can see hits your beast companion with an attack, you can call out a warning. If your beast companion can hear you, it can use its reaction to halve the attack’s damage against it.</description>
+		</sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20150406_RANGER_ARCHETYPE_BEAST_MASTER_BEASTLY_COORDINATION" />
+        </rules>
+	</element>
+    <element name="Superior Beast's Defense" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_BEAST_SUPERIOR_BEASTS_DEFENSE">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>Beginning at 15th level, whenever an attacker that your companion can see hits it with an attack, it can use its reaction to halve the attack's damage against it.</p>
+        </description>
+        <sheet display="false">
+            <description>Whenever an attacker that your companion can see hits it with an attack, it can use its reaction to halve the attack's damage against it.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_SUPERIOR_BEASTS_DEFENSE" />
+        </rules>
+    </element>
+    <element name="Shadowy Dodge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_GLOOM_SHADOWY_DODGE">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>Starting at 15th level, you can dodge in unforeseen ways, with wisps of supernatural shadow around you. Whenever a creature makes an attack roll against you and doesn’t have advantage on the roll, you can use your reaction to impose disadvantage on it. You must use this feature before you know the outcome of the attack roll.</p>
+        </description>
+        <sheet display="false">
+            <description>Reaction: When a creature makes an attack roll against you and doesn’t have advantage on the roll, impose disadvantage on it (before knowing the outcome of the attack roll).</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_SHADOWY_DODGE" />
+        </rules>
+    </element>
+    <element name="Slayer's Counter" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_SLAYER_SLAYERS_COUNTER">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>At 15th level, you gain the ability to counterattack when your prey tries to sabotage you. If the target of your Slayer’s Prey forces you to make a saving throw, you can use your reaction to make one weapon attack against the quarry. You make this attack immediately before making the saving throw. If your attack hits, your save automatically succeeds, in addition to the attack’s normal effects.</p>
+        </description>
+        <sheet display="false">
+            <description>If the target of your Slayer’s Prey forces you to make a saving throw, make one weapon attack against it. You make this attack immediately before making the saving throw. If your attack hits, your save automatically succeeds, in addition to the attack’s normal effects.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SLAYERS_COUNTER" />
+        </rules>
+    </element>
+    <element name="Spectral Defense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_CONSTRUCTOR_HORIZON_WALKER_SPECTRAL_DEFENSE">
+        <supports>Ranger Archetype Constructor, 6th Archetype Feature</supports>
+        <description>
+            <p>At 15th level, your ability to move between planes enables you to slip through the planar boundaries to lessen the harm done to you during battle. When you take damage from an attack, you can use your reaction to give yourself resistance to all of that attack’s damage on this turn.</p>
+        </description>
+        <sheet display="false">
+            <description>When you take damage from an attack, you can use your reaction to give yourself resistance to all of that attack’s damage on this turn.</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_HORIZON_WALKER_SPECTRAL_DEFENSE" />
+        </rules>
+    </element>
+
+    <!-- Ranger Archetype Constructor, 6th Archetype Features -->
+    <element name="Superior Hunter’s Defense" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE">
+        <description>
+            <p>At 15th level, you gain one of the following features of your choice.</p>
+            <p>
+                <span class="feature">Evasion.</span>You can nimbly dodge out of the way of certain area effects, such as a red dragon’s fiery breath or a lightning bolt spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.
+                <br/>
+                <span class="feature">Stand Against the Tide.</span>When a hostile creature misses you with a melee attack, you can use your reaction to force that creature to repeat the same attack against another creature (other than itself) of your choice.
+                <br/>
+                <span class="feature">Uncanny Dodge.</span>When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack’s damage against you.
+                <br/>
+            </p>
+        </description>
+        <sheet>
+            <description></description>
+        </sheet>
+        <rules>
+            <select type="Archetype Feature" name="Superior Hunter’s Defense" supports="Superior Hunters Defense" />
+        </rules>
+    </element>
+
+    <element name="Share Spells" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_BEAST_SHARE_SPELLS">
+        <description>
+            <p>Beginning at 15th level, when you cast a spell targeting yourself, you can also affect your beast companion with the spell if the beast is within 30 feet of you.</p>
+        </description>
+        <sheet>
+            <description>When you cast a spell targeting yourself, you can also affect your beast companion with the spell if the beast is within 30 feet of you.</description>
+        </sheet>
+    </element>
+
+	<element name="Beastly Coordination" type="Archetype Feature" source="Unearthed Arcana: Modifying Classes" id="ID_WOTC_UA20150406_RANGER_ARCHETYPE_BEAST_MASTER_BEASTLY_COORDINATION">
+		<description>
+			<p>Beginning at 15th level, when an attacker that you can see hits your beast companion with an attack, you can call out a warning. If your beast companion can hear you, it can use its reaction to halve the attack’s damage against it.</p>
+		</description>
+		<sheet>
+			<description>When an attacker that you can see hits your beast companion with an attack, you can call out a warning. If your beast companion can hear you, it can use its reaction to halve the attack’s damage against it.</description>
+		</sheet>
+	</element>
+
+    <element name="Superior Beast's Defense" type="Archetype Feature" source="Unearthed Arcana: Revised Ranger" id="ID_WOTC_UA20160912_ARCHETYPE_FEATURE_RANGER_BEAST_SUPERIOR_BEASTS_DEFENSE">
+        <description>
+            <p>Beginning at 15th level, whenever an attacker that your companion can see hits it with an attack, it can use its reaction to halve the attack's damage against it.</p>
+        </description>
+        <sheet>
+            <description>Whenever an attacker that your companion can see hits it with an attack, it can use its reaction to halve the attack's damage against it.</description>
+        </sheet>
+    </element>
+
+    <element name="Shadowy Dodge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_GLOOM_SHADOWY_DODGE">
+        <description>
+            <p>Starting at 15th level, you can dodge in unforeseen ways, with wisps of supernatural shadow around you. Whenever a creature makes an attack roll against you and doesn’t have advantage on the roll, you can use your reaction to impose disadvantage on it. You must use this feature before you know the outcome of the attack roll.</p>
+        </description>
+        <sheet>
+            <description>Reaction: When a creature makes an attack roll against you and doesn’t have advantage on the roll, impose disadvantage on it (before knowing the outcome of the attack roll).</description>
+        </sheet>
+    </element>
+
+    <element name="Slayer's Counter" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_SLAYER_SLAYERS_COUNTER">
+        <description>
+            <p>At 15th level, you gain the ability to counterattack when your prey tries to sabotage you. If the target of your Slayer’s Prey forces you to make a saving throw, you can use your reaction to make one weapon attack against the quarry. You make this attack immediately before making the saving throw. If your attack hits, your save automatically succeeds, in addition to the attack’s normal effects.</p>
+        </description>
+        <sheet action="Reaction">
+            <description>If the target of your Slayer’s Prey forces you to make a saving throw, make one weapon attack against it. You make this attack immediately before making the saving throw. If your attack hits, your save automatically succeeds, in addition to the attack’s normal effects.</description>
+        </sheet>
+    </element>
+
+    <element name="Spectral Defense" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_RANGER_HORIZON_WALKER_SPECTRAL_DEFENSE">
+        <description>
+            <p>At 15th level, your ability to move between planes enables you to slip through the planar boundaries to lessen the harm done to you during battle. When you take damage from an attack, you can use your reaction to give yourself resistance to all of that attack’s damage on this turn.</p>
+        </description>
+        <sheet>
+            <description>When you take damage from an attack, you can use your reaction to give yourself resistance to all of that attack’s damage on this turn.</description>
+        </sheet>
+    </element>
+
+    <!-- Hunter’s Prey Options -->
+    <element name="Colossus Slayer" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY_COLOSSUS_SLAYER">
+        <supports>Hunters Pray</supports>
+        <description>
+        <p>Your tenacity can wear down the most potent foes. When you hit a creature with a weapon attack, the creature takes an extra 1d8 damage if it’s below its hit point maximum. You can deal this extra damage only once per turn.</p>
+        </description>
+        <sheet>
+        <description>Your tenacity can wear down the most potent foes. When you hit a creature with a weapon attack, the creature takes an extra 1d8 damage if it’s below its hit point maximum. You can deal this extra damage only once per turn.</description>
+        </sheet>
+    </element>
+    <element name="Giant Killer" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY_GIANT_KILLER">
+        <supports>Hunters Pray</supports>
+        <description>
+        <p>When a Large or larger creature within 5 feet of you hits or misses you with an attack, you can use your reaction to attack that creature immediately after its attack, provided that you can see the creature.</p>
+        </description>
+        <sheet>
+        <description>When a Large or larger creature within 5 feet of you hits or misses you with an attack, you can use your reaction to attack that creature immediately after its attack, provided that you can see the creature.</description>
+        </sheet>
+    </element>
+    <element name="Horde Breaker" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_HUNTERS_PREY_HORDE_BREAKER">
+        <supports>Hunters Pray</supports>
+        <description>
+        <p>Once on each of your turns when you make a weapon attack, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon.</p>
+        </description>
+        <sheet>
+        <description>Once on each of your turns when you make a weapon attack, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon.</description>
+        </sheet>
+    </element>
+    <!-- Defensive Tactics -->
+    <element name="Escape the Horde" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS_ESCAPE_THE_HORDE">
+        <supports>Defensive Tactics</supports>
+        <description>
+        <p>Opportunity attacks against you are made with disadvantage.</p>
+        </description>
+        <sheet>
+        <description>Opportunity attacks against you are made with disadvantage.</description>
+        </sheet>
+    </element>
+    <element name="Multiattack Defense" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS_MULTIATTACK_DEFENSE">
+        <supports>Defensive Tactics</supports>
+        <description>
+        <p>When a creature hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the turn.</p>
+        </description>
+        <sheet>
+        <description>When a creature hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the turn.</description>
+        </sheet>
+    </element>
+    <element name="Steel Will" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_DEFENSIVE_TACTICS_STEEL_WILL">
+        <supports>Defensive Tactics</supports>
+        <description>
+        <p>You have advantage on saving throws against being frightened.</p>
+        </description>
+        <sheet>
+        <description>You have advantage on saving throws against being frightened.</description>
+        </sheet>
+    </element>
+    <!-- Multiattack -->
+    <element name="Volley" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_MULTIATTACK_VOLLEY">
+        <supports>Multiattack</supports>
+        <description>
+        <p>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon’s range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target.</p>
+        </description>
+        <sheet>
+        <description>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon’s range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target.</description>
+        </sheet>
+    </element>
+    <element name="Whirlwind Attack" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_MULTIATTACK_WHIRLWIND_ATTACK">
+        <supports>Multiattack</supports>
+        <description>
+        <p>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</p>
+        </description>
+        <sheet>
+        <description>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</description>
+        </sheet>
+    </element>
+    <!-- Superior Hunter’s Defense -->
+    <element name="Evasion" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE_EVASION">
+        <supports>Superior Hunters Defense</supports>
+        <description>
+        <p>You can nimbly dodge out of the way of certain area effects, such as a red dragon’s fiery breath or a lightning bolt spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.</p>
+        </description>
+        <sheet>
+        <description>You can nimbly dodge out of the way of certain area effects, such as a red dragon’s fiery breath or a lightning bolt spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.</description>
+        </sheet>
+    </element>
+    <element name="Stand Against the Tide" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE_STAND_AGAINST_THE_TIDE">
+        <supports>Superior Hunters Defense</supports>
+        <description>
+        <p>When a hostile creature misses you with a melee attack, you can use your reaction to force that creature to repeat the same attack against another creature (other than itself) of your choice.</p>
+        </description>
+        <sheet>
+        <description>When a hostile creature misses you with a melee attack, you can use your reaction to force that creature to repeat the same attack against another creature (other than itself) of your choice.</description>
+        </sheet>
+    </element>
+    <element name="Uncanny Dodge" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_SUPERIOR_HUNTERS_DEFENSE_UNCANNY_DODGE">
+        <supports>Superior Hunters Defense</supports>
+        <description>
+        <p>When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack’s damage against you.</p>
+        </description>
+        <sheet>
+        <description>When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack’s damage against you.</description>
+        </sheet>
+    </element>
+
+    <!-- Elemental Companion Options -->
+	<element name="Beast of the Air" type="Companion" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR">
+		<description />
+		<setters>
+			<set name="strength">6</set>
+			<set name="dexterity">16</set>
+			<set name="constitution">13</set>
+			<set name="intelligence">8</set>
+			<set name="wisdom">14</set>
+			<set name="charisma">11</set>
+			<set name="ac">13</set>
+			<set name="hp">equal the beast’s Constitution modifier + your Wisdom modifier + five times your ranger level (the beast has a number of Hit Dice [d6s] equal to your ranger level)</set>
+			<set name="speed">10 ft., fly 60 ft.</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="skills">Perception +4, Stealth +5</set>
+			<set name="type">Beast</set>
+			<set name="size">Small</set>
+			<set name="alignment">neutral</set>
+			<set name="challenge">1/4</set>
+			<set name="traits">ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_FLYBY,ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_PRIMAL_REBIRTH,ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_READY_COMPANION</set>
+			<set name="actions">ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_SHRED</set>
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="13" />
+			<stat name="companion:hp:max" value="1" bonus="base" />
+			<stat name="companion:speed" value="10" bonus="base" />
+			<stat name="companion:speed:fly" value="60" bonus="base" />
+			<stat name="companion:stealth:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+            <!-- beast’s Constitution modifier + your Wisdom modifier + five times your ranger level -->
+			<stat name="_alternative:hp:max" value="companion:constitution:modifier" bonus="beast-CON Mod" />
+			<stat name="_alternative:hp:max" value="wisdom:modifier" bonus="WIS Mod" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+		</rules>
+	</element>
+	<element name="Flyby" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_FLYBY">
+		<description>
+			<p>The beast doesn’t provoke opportunity attacks when it flies out of an enemy’s reach.</p>
+		</description>
+		<sheet>
+			<description>The beast doesn’t provoke opportunity attacks when it flies out of an enemy’s reach.</description>
+		</sheet>
+	</element>
+	<element name="Primal Rebirth" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_PRIMAL_REBIRTH">
+		<description>
+			<p>If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored.</p>
+		</description>
+		<sheet>
+			<description>If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored.</description>
+		</sheet>
+	</element>
+	<element name="Ready Companion" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_READY_COMPANION">
+		<description>
+			<p>As a bonus action, you can command the beast to make its shred attack or to Hide.</p>
+		</description>
+		<sheet>
+			<description>As a bonus action, you can command the beast to make its shred attack or to Hide.</description>
+		</sheet>
+	</element>
+	<element name="Shred" type="Companion Action" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_AIR_SHRED">
+		<description>
+			<p>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d6 + 3 slashing damage.</p>
+		</description>
+		<sheet>
+			<description>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d6 + 3 slashing damage.</description>
+		</sheet>
+	</element>
+
+	<element name="Beast of the Earth" type="Companion" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH">
+		<description />
+		<setters>
+			<set name="strength">14</set>
+			<set name="dexterity">14</set>
+			<set name="constitution">15</set>
+			<set name="intelligence">8</set>
+			<set name="wisdom">14</set>
+			<set name="charisma">11</set>
+			<set name="ac">12</set>
+			<set name="hp">equal the beast’s Constitution modifier + your Wisdom modifier + five times your ranger level (the beast has a number of Hit Dice [d6s] equal to your ranger level)</set>
+			<set name="speed">40 ft., climb or swim 40 ft. (your choice when you bond with the beast)</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="skills">Perception +4, Stealth +4</set>
+			<set name="type">Beast</set>
+			<set name="size">Medium</set>
+			<set name="alignment">neutral</set>
+			<set name="challenge">1/4</set>
+			<set name="traits">ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_CHARGE,ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_PRIMAL_REBIRTH,ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_READY_COMPANION</set>
+			<set name="actions">ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_MAUL></set>
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="12" />
+			<stat name="companion:hp:max" value="1" bonus="base" />
+			<stat name="companion:speed" value="40" bonus="base" />
+            <select type="Companion Trait" name="Companion Speed" supports="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_SPEED_CLIMB|ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_SPEED_SWIM" />
+			<stat name="companion:stealth:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+            <!-- beast’s Constitution modifier + your Wisdom modifier + five times your ranger level -->
+			<stat name="_alternative:hp:max" value="companion:constitution:modifier" bonus="beast-CON Mod" />
+			<stat name="_alternative:hp:max" value="wisdom:modifier" bonus="WIS Mod" />
+            <stat name="_alternative:hp:max" value="level:ranger constructor" />
+		</rules>
+	</element>
+	<element name="Speed: Swim 40ft." type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_SPEED_SWIM">
+		<description>
+			<p>Your beast swimming speed is 40 ft.</p>
+		</description>
+		<sheet display="false">
+			<description>Your beast swimming speed is 40 ft.</description>
+		</sheet>
+		<rules>
+			<stat name="companion:speed:swim" value="40" bonus="base" />
+		</rules>
+	</element>
+	<element name="Speed: Climb 40ft." type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_SPEED_CLIMB">
+		<description>
+			<p>Your beast climbing speed is 40 ft.</p>
+		</description>
+		<sheet>
+			<description>Your beast climbing speed is 40 ft.</description>
+		</sheet>
+		<rules>
+			<stat name="companion:speed:climb" value="40" bonus="base" />
+		</rules>
+	</element>
+	<element name="Charge" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_CHARGE">
+		<description>
+			<p>If the beast moves at least 20 feet straight toward a target and then hits it with a maul attack on the same turn, the target takes an extra 1d6 slashing damage. The DC equals your spell save DC. If the target is a creature, it must succeed on a Strength saving throw against your spell save DC or be knocked prone.</p>
+		</description>
+		<sheet>
+			<description>If the beast moves at least 20 feet straight toward a target and then hits it with a maul attack on the same turn, the target takes an extra 1d6 slashing damage. The DC equals your spell save DC. If the target is a creature, it must succeed on a Strength saving throw against your spell save DC or be knocked prone.</description>
+		</sheet>
+	</element>
+	<element name="Primal Rebirth" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_PRIMAL_REBIRTH">
+		<description>
+			<p>If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored.</p>
+		</description>
+		<sheet>
+			<description>If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored.</description>
+		</sheet>
+	</element>
+	<element name="Ready Companion" type="Companion Trait" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_READY_COMPANION">
+		<description>
+			<p>As a bonus action, you can command the beast to make its shred attack or to Hide.</p>
+		</description>
+		<sheet>
+			<description>As a bonus action, you can command the beast to make its shred attack or to Hide.</description>
+		</sheet>
+	</element>
+	<element name="Maul" type="Companion Action" source="Unearthed Arcana: Class Feature Variants" id="ID_WOTC_UA20191104_COMPANION_BEAST_OF_THE_EARTH_MAUL>">
+		<description>
+			<p>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d6 + 2 slashing damage.</p>
+		</description>
+		<sheet>
+			<description>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d6 + 2 slashing damage.</description>
+		</sheet>
+	</element>
+
+    <!-- Sources -->
+	<element name="Unearthed Arcana: Modifying Classes" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20150406">
+		<description>
+			<p>Sometimes a campaign will have special needs for archetypes or character options not found in the existing official material. If you’re in this situation, you might want to modify one or more of the classes in the game in order to provide options for players looking for a unique twist on their characters’ abilities. However, modifying a class is not something that should be undertaken lightly, and the job requires some serious effort, playtesting, and revision to get it right. The two best ways to modify a class are to swap out some class features for different ones, and to add new to an existing class. This article presents methods that will help you to use existing mechanics as a model, while drawing upon features of other classes for inspiration.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20150406</set>
+			<set name="url">https://dnd.wizards.com/articles/unearthed-arcana/modifying-classes</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20150406</set>
+		</setters>
+	</element>
+	<element name="Unearthed Arcana: Ranger" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20150909">
+		<description>
+			<p>The ranger has been a part of Dungeons &amp; Dragons since almost the beginning, and it remains one of the most popular classes in the game. However, feedback on fifth edition D&amp;D has shown that the ranger lags behind the other classes in terms of power and player satisfaction. This installment of Unearthed Arcana presents a revised design of the ranger that builds on the class’s unique traits, creating a new set of class features for 1st level to 5th level. These features are designed to make the ranger feel distinct and interesting while still remaining true to its identity within the game.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20150909</set>
+			<set name="url">http://dnd.wizards.com/articles/unearthed-arcana/ranger</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20150909</set>
+		</setters>
+	</element>
+	<element name="Unearthed Arcana: Revised Ranger" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20160912">
+		<description>
+			<p>Over the past year, you’ve seen us try a number of new approaches to the ranger, all aimed at addressing the class’s high levels of player dissatisfaction and its ranking as D&amp;D’s weakest class by a significant margin.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20160912</set>
+			<set name="url">http://dnd.wizards.com/articles/features/unearthed-arcana-ranger-revised</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20160912</set>
+		</setters>
+	</element>
+	<element name="Unearthed Arcana: Class Feature Variants" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20191104">
+		<description>
+			<p>Every character class in D&amp;D has features, and every class gets one or more class feature variants in today’s <i>Unearthed Arcana</i>! These variants replace or enhance a class’s normal features, giving you new ways to enjoy your character’s class.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20191104</set>
+			<set name="url">https://dnd.wizards.com/articles/unearthed-arcana/class-feature-variants</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20191104</set>
+		</setters>
+	</element>
+	<element name="Xanathar’s Guide to Everything" type="Source" source="Xanathar’s Guide to Everything" id="ID_WOTC_SOURCE_XANATHARS_GUIDE_TO_EVERYTHING">
+		<description>
+			<![CDATA[<p><strong>Explore a wealth of new rules options for both players and Dungeon Masters in this supplement for the world’s greatest roleplaying game.</strong></p><p>The beholder Xanathar—Waterdeep’s most infamous crime lord—is known to hoard information on friend and foe alike. The beholder catalogs lore about adventurers and ponders methods to thwart them. Its twisted mind imagines that it can eventually record everything!</p><p>Xanathar's Guide to Everything is the first major expansion for fifth edition Dungeons &amp; Dragons, offering new rules and story options:</p><ul><li>Over twenty-five new subclasses for the character classes in the Player’s Handbook, including the Cavalier for the fighter, the Circle of Dreams for the druid, the Horizon Walker for the ranger, the Inquisitive for the rogue, and many more.</li><li>Dozens of new spells, a collection of racial feats, and a system to give your character a randomized backstory.</li><li>A variety of tools that provide Dungeon Masters fresh ways to use traps, magic items, downtime activities, and more—all designed to enhance a D&amp;D campaign and push it in new directions.</li></ul><p>Amid all this expansion material, Xanathar offers bizarre observations about whatever its eyestalks happen to glimpse. Pray they don’t come to rest on you.</p><p><strong>Beauty and guile are in the eyes of the beholder!</strong></p>]]>
+		</description>
+		<setters>
+			<set name="abbreviation">XGTE</set>
+			<set name="url">http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything</set>
+			<set name="image">https://media.dnd.wizards.com/styles/products_thumbnail/public/images/product/DX_Xanathar_ProductShotv2_0.png</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="supplement">true</set>
+			<set name="release">20171121</set>
+		</setters>
+	</element>
+
+<!-- Current issues:
+        1. Favored Enemy from Revised Ranger should get stats for +[2/4] attack damage bonus.
+        2. Greater Favored Enemy should be locked behind a requirement of Favored Enemy from Revised Ranger
+        3. Natural Antivenom should be locked behind Poultices from Modifying Classes
+        4. Relentless should be locked behind Combat Superiority from Modifying Classes -->
+
+</elements>


### PR DESCRIPTION
Current issues:
1. Favored Enemy from Revised Ranger should get stats for +[2/4] attack damage bonus.
2. Greater Favored Enemy should be locked behind a requirement of Favored Enemy from Revised Ranger
3. Natural Antivenom should be locked behind Poultices from Modifying Classes
4. Relentless should be locked behind Combat Superiority from Modifying Classes